### PR TITLE
[SHM_WRAPPER] added shm_wrapper_aux and associated tests; bug fixes on device shm wrapper

### DIFF
--- a/runtime_util/runtime_util.h
+++ b/runtime_util/runtime_util.h
@@ -5,11 +5,40 @@
 
 // ***************************** DEFINED CONSTANTS ************************** //
 
-//enumerate names of processes
-typedef enum process { DEV_HANDLER, EXECUTOR, NET_HANDLER } process_t;
-
 #define MAX_DEVICES 32 //maximum number of connected devices
 #define MAX_PARAMS 32 //maximum number of parameters per connected device
+
+#define NUM_DESC_FIELDS 6                   //number of fields in the robot description
+#define NUM_GAMEPAD_BUTTONS 17              //number of gamepad buttons
+
+//enumerate names of processes
+typedef enum process { 
+	DEV_HANDLER, EXECUTOR, NET_HANDLER 
+} process_t;
+
+//enumerated names for the buttons on the gamepad
+typedef enum gp_buttons {
+	A_BUTTON, B_BUTTON, X_BUTTON, Y_BUTTON, L_BUMPER, R_BUMPER, L_TRIGGER, R_TRIGGER,
+	BACK_BUTTON, START_BUTTON, L_STICK, R_STICK, UP_DPAD, DOWN_DPAD, LEFT_DPAD, RIGHT_DPAD, XBOX_BUTTON
+} gp_button_t;
+
+//enumerated names for the joystick params of the gamepad
+typedef enum gp_joysticks {
+	X_LEFT_JOYSTICK, Y_LEFT_JOYSTICK, X_RIGHT_JOYSTICK, Y_RIGHT_JOYSTICK
+} gp_joystick_t;
+
+//enumerated names for the different values the robot description fields can take on
+typedef enum robot_desc_vals {
+	ISSUE, NOMINAL,             //values for robot.state
+	IDLE, AUTO, TELEOP,         //values for robot.run_mode
+	CONNECTED, DISCONNECTED,    //values for robot.dawn, robot.shepherd, robot.gamepad
+	BLUE, GOLD                  //values for robot.team
+} robot_desc_val_t;
+
+//enumerated names for the fields in the robot description
+typedef enum robot_descs {
+	STATE, RUN_MODE, DAWN, SHEPHERD, GAMEPAD, TEAM
+} robot_desc_field_t;
 
 // ******************************* CUSTOM STRUCTS ************************** //
 

--- a/runtime_util/runtime_util.h
+++ b/runtime_util/runtime_util.h
@@ -8,7 +8,7 @@
 #define MAX_DEVICES 32 //maximum number of connected devices
 #define MAX_PARAMS 32 //maximum number of parameters per connected device
 
-#define NUM_DESC_FIELDS 6                   //number of fields in the robot description
+#define NUM_DESC_FIELDS 5                   //number of fields in the robot description
 #define NUM_GAMEPAD_BUTTONS 17              //number of gamepad buttons
 
 //enumerate names of processes
@@ -29,7 +29,6 @@ typedef enum gp_joysticks {
 
 //enumerated names for the different values the robot description fields can take on
 typedef enum robot_desc_vals {
-	ISSUE, NOMINAL,             //values for robot.state
 	IDLE, AUTO, TELEOP,         //values for robot.run_mode
 	CONNECTED, DISCONNECTED,    //values for robot.dawn, robot.shepherd, robot.gamepad
 	BLUE, GOLD                  //values for robot.team
@@ -37,7 +36,7 @@ typedef enum robot_desc_vals {
 
 //enumerated names for the fields in the robot description
 typedef enum robot_descs {
-	STATE, RUN_MODE, DAWN, SHEPHERD, GAMEPAD, TEAM
+	RUN_MODE, DAWN, SHEPHERD, GAMEPAD, TEAM
 } robot_desc_field_t;
 
 // ******************************* CUSTOM STRUCTS ************************** //

--- a/shm_wrapper/Makefile
+++ b/shm_wrapper/Makefile
@@ -1,9 +1,9 @@
 # Change depending on Linux or Mac. Code won't work on Windows :(
-LIBFLAGS=-lrt -lpthread # Linux
-# LIBFLAGS=               # Mac
+# LIBFLAGS=-lrt -lpthread # Linux
+LIBFLAGS=               # Mac
 
-test1: shm_wrapper_test1.c shm_wrapper.c
-	gcc shm_wrapper_test1.c shm_wrapper.c -o test1 $(LIBFLAGS)
+test1: shm_wrapper_test1.c shm_wrapper.c ../logger/logger.c ../logger/logger_config.h
+	gcc shm_wrapper_test1.c shm_wrapper.c ../logger/logger.c -o test1 $(LIBFLAGS)
 	
-test2: shm_wrapper_test2.c shm_wrapper.c
-	gcc shm_wrapper_test2.c shm_wrapper.c -o test2 $(LIBFLAGS)
+test2: shm_wrapper_test2.c shm_wrapper.c ../logger/logger.c ../logger/logger_config.h
+	gcc shm_wrapper_test2.c shm_wrapper.c ../logger/logger.c -o test2 $(LIBFLAGS)

--- a/shm_wrapper/connect_static_devices.c
+++ b/shm_wrapper/connect_static_devices.c
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <signal.h>
+#include "shm_wrapper.h"
+
+void ctrl_c_handler (int sig_num)
+{
+	printf("Aborting and cleaning up\n");
+	fflush(stdout);
+	shm_stop(DEV_HANDLER);
+	logger_stop(DEV_HANDLER);
+	exit(1);
+}
+
+int main()
+{
+	int dev_ix = -1;
+	param_val_t params_in[MAX_PARAMS];
+	
+	shm_init(DEV_HANDLER);
+	logger_init(DEV_HANDLER);
+	signal(SIGINT, ctrl_c_handler); //hopefully fails gracefully when pressing Ctrl-C in the terminal
+
+	//connect as many devices as possible
+	for (int i = 0; i < MAX_DEVICES; i++) {
+		//randomly chosen quadratic function that is positive and integral in range [0, 32] for the lols
+		device_connect(i, i % 3, (-10000 * i * i) + (297493 * i) + 474732, &dev_ix);
+		for (int j = 0; j < MAX_PARAMS; j++) {
+			params_in[j].p_i = j * i * MAX_DEVICES;
+			params_in[j].p_f = (float)(j * i * MAX_DEVICES * 3.14159);
+			params_in[j].p_b = (i % 2 == 0) ? 0 : 1;
+		}
+		device_write(i, DEV_HANDLER, UPSTREAM, 4294967295, params_in)
+	}
+	print_dev_ids();
+	
+	while (1) {
+		usleep(1000);
+	}
+	
+	return 0;
+}

--- a/shm_wrapper/shm_wrapper.c
+++ b/shm_wrapper/shm_wrapper.c
@@ -297,6 +297,10 @@ void shm_init (process_t process)
 			error("sem_open: pmap_mutex@client");
 		}
 		
+		//wait on catalog_sem to ensure shm has been created before opening
+		if (sem_wait(catalog_sem) == -1) {
+			error("sem_wait: catalog_mutex@client");
+		}
 		
 		//open shared memory block and map to client process virtual memory
 		if ((fd_shm = shm_open(SHARED_MEM_NAME, O_RDWR, 0)) == -1) { //no O_CREAT
@@ -319,6 +323,11 @@ void shm_init (process_t process)
 			if ((sems[i].command_sem = sem_open((const char *) sname, 0, 0, 0)) == SEM_FAILED) { //no O_CREAT
 				error("sem_open: command sem@client");
 			}
+		}
+		
+		//release catalog_sem
+		if (sem_post(catalog_sem) == -1) {
+			error("sem_post: catalog_mutex@client");
 		}
 	}
 }

--- a/shm_wrapper/shm_wrapper.c
+++ b/shm_wrapper/shm_wrapper.c
@@ -409,7 +409,7 @@ void device_connect (uint16_t dev_type, uint8_t dev_year, uint64_t dev_uid, int 
 		}
 	}
 	if (*dev_ix == MAX_DEVICES) {
-		log_runtime(WARN, "too many devices, connection unsuccessful");
+		log_runtime(ERROR, "too many devices, connection unsuccessful");
 		if (sem_post(catalog_sem) == -1) { //release the catalog semaphore
 			error("sem_post: catalog_sem");
 		}

--- a/shm_wrapper/shm_wrapper.c
+++ b/shm_wrapper/shm_wrapper.c
@@ -46,7 +46,6 @@ sem_t *pmap_sem;                    //semaphore used as a mutex on the param bit
 
 // ******************************************** HELPER FUNCTIONS ****************************************** //
 
-// Replace with logger
 static void error (char *msg)
 {
 	perror(msg);
@@ -187,7 +186,7 @@ void shm_init (process_t process)
 		
 		//initialization complete; set catalog_mutex to 1 indicating shm segment available for client(s)
 		if (sem_post(catalog_sem) == -1) {
-			error("sem_post: conn_sem@dev_handler");
+			error("sem_post: catalog_sem@dev_handler");
 		}
 	} else {
 		//mutual exclusion semaphore, catalog_mutex

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -83,6 +83,12 @@ No return value.
 */
 void device_read (int dev_ix, process_t process, stream_t stream, uint32_t params_to_read, param_val_t *params);
 
+/*
+This function is the exact same as the above function, but instead uses the 64-bit device UID to identify
+the device that should be read, rather than the device index.
+*/
+void device_read_uid (uint64_t dev_uid, process_t process, stream_t stream, uint32_t params_to_read, param_val_t *params);
+
 /*	
 Should be called from every process wanting to write to the device data
 Takes care of updating the param bitmap for fast transfer of commands from executor to device handler
@@ -97,6 +103,12 @@ Grabs either one or two semaphores depending on calling process and stream reque
 No return value.
 */
 void device_write (int dev_ix, process_t process, stream_t stream, uint32_t params_to_write, param_val_t *params);
+
+/*
+This function is the exact same as the above function, but instead uses the 64-bit device UID to identify
+the device that should be written, rather than the device index.
+*/
+void device_write_uid (uint64_t dev_uid, process_t process, stream_t stream, uint32_t params_to_write, param_val_t *params);
 
 /*
 Should be called from all processes that want to know current state of the param bitmap (i.e. device handler)

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -10,6 +10,7 @@
 #include <unistd.h>                        //for standard symbolic constants
 #include <semaphore.h>                     //for semaphores
 #include <sys/mman.h>                      //for posix shared memory
+#include "../logger/logger.h"              //for logger (TODO: consider removing relative pathname in include)
 #include "../runtime_util/runtime_util.h"  //for runtime constants (TODO: consider removing relative pathname in include)
 
 //enumerated names for the two associated blocks per device

--- a/shm_wrapper/shm_wrapper_test2.c
+++ b/shm_wrapper/shm_wrapper_test2.c
@@ -364,6 +364,7 @@ void ctrl_c_handler (int sig_num)
 	printf("Aborting and cleaning up\n");
 	fflush(stdout);
 	shm_stop(EXECUTOR);
+	logger_stop(EXECUTOR);
 	exit(1);
 }
 

--- a/shm_wrapper_aux/Makefile
+++ b/shm_wrapper_aux/Makefile
@@ -1,0 +1,9 @@
+# Change depending on Linux or Mac. Code won't work on Windows :(
+# LIBFLAGS=-lrt -lpthread # Linux
+LIBFLAGS=               # Mac
+
+test1: shm_wrapper_aux_test1.c shm_wrapper_aux.c ../logger/logger.c ../logger/logger_config.h
+	gcc shm_wrapper_aux_test1.c shm_wrapper_aux.c ../logger/logger.c -o test1 $(LIBFLAGS)
+	
+test2: shm_wrapper_aux_test2.c shm_wrapper_aux.c ../logger/logger.c ../logger/logger_config.h
+	gcc shm_wrapper_aux_test2.c shm_wrapper_aux.c ../logger/logger.c -o test2 $(LIBFLAGS)

--- a/shm_wrapper_aux/shm_wrapper_aux.c
+++ b/shm_wrapper_aux/shm_wrapper_aux.c
@@ -395,7 +395,7 @@ void gamepad_read (process_t process, uint32_t *pressed_buttons, float *joystick
 	
 	//if no gamepad connected, then release rd_sem and return
 	if (rd_ptr->fields[GAMEPAD] == DISCONNECTED) {
-		log_runtime(WARN, "tried to read, but no gamepad connected");
+		log_runtime(ERROR, "tried to read, but no gamepad connected");
 		if (sem_post(rd_sem) == -1) {
 			error("sem_post: robot_desc_mutex");
 		}
@@ -440,7 +440,7 @@ void gamepad_write (process_t process, uint32_t pressed_buttons, float *joystick
 	
 	//if no gamepad connected, then release rd_sem and return
 	if (rd_ptr->fields[GAMEPAD] == DISCONNECTED) {
-		log_runtime(WARN, "tried to write, but no gamepad connected");
+		log_runtime(ERROR, "tried to write, but no gamepad connected");
 		if (sem_post(rd_sem) == -1) {
 			error("sem_post: robot_desc_mutex");
 		}

--- a/shm_wrapper_aux/shm_wrapper_aux.c
+++ b/shm_wrapper_aux/shm_wrapper_aux.c
@@ -212,6 +212,10 @@ void shm_aux_init (process_t process)
 			error("sem_open: robot_desc_mutex@client");
 		}
 		
+		//wait on gp_sem to ensure shm has been created before opening
+		if (sem_wait(gp_sem) == -1) {
+			error("sem_wait: gamepad_mutex@client");
+		}
 		
 		//open gamepad shm block and map to client process virtual memory
 		if ((fd_shm = shm_open(GPAD_SHM_NAME, O_RDWR, 0)) == -1) { //no O_CREAT
@@ -233,6 +237,11 @@ void shm_aux_init (process_t process)
 		}
 		if (close(fd_shm) == -1) {
 			error("close: @client");
+		}
+		
+		//release gp_sem
+		if (sem_post(gp_sem) == -1) {
+			error("sem_post: gamepad_mutex@client");
 		}
 	}
 }

--- a/shm_wrapper_aux/shm_wrapper_aux.c
+++ b/shm_wrapper_aux/shm_wrapper_aux.c
@@ -1,0 +1,431 @@
+#include "shm_wrapper.h"
+
+/*
+Useful function definitions:
+
+int shm_open (const char *name, int oflag, mode_t mode); //if O_CREAT is not specified or the shm object exists, mode is ignored
+int shm_unlink (const char *name);
+void *mmap (void *addr, size_t length, int prot, int flags, int fd, off_t offset);
+int munmap (void *addr, size_t length);
+int ftruncate (int fd, off_t length);
+
+sem_t *sem_open (const char *name, int oflag, mode_t mode, unsigned int value); //if O_CREAT is not specified or the sem exists, mode is ignored
+int sem_unlink (const char *name);
+int sem_wait (sem_t *sem);
+int sem_post (sem_t *sem);
+*/
+
+#define GPAD_SHM_NAME "/gp-shm"         //name of shared memory block for gamepad
+#define ROBOT_DESC_SHM_NAME "/rd-shm"   //name of shared memory block for robot description
+#define GP_MUTEX_NAME "/gp-sem"         //name of semaphore used as mutex over gamepad shm
+#define RD_MUTEX_NAME "/rd-sem"         //name of semaphore used as mutex over robot description shm
+
+#define NUM_DESC_FIELDS 6               //number of fields in the robot description
+#define NUM_GAMEPAD_BUTTONS 17          //number of gamepad buttons
+
+// ***************************************** PRIVATE TYPEDEFS ********************************************* //
+
+//shared memory for gamepad
+typedef struct gp {
+	uint32_t buttons;                   //bitmap for which buttons are pressed
+	float joysticks[4];                 //array to hold joystick positions
+} gamepad_t;
+
+//shared memory for robot description
+typedef struct robot_desc {
+	uint8_t fields[NUM_DESC_FIELDS];    //array to hold the robot state (each is a uint8_t)
+} robot_desc_t;
+
+// *********************************** WRAPPER-SPECIFIC GLOBAL VARS **************************************** //
+
+gamepad_t *gp_ptr;                      //points to memory-mapped shared memory block for gamepad
+robot_desc_t *rd_ptr;                   //points to memory-mapped shared memory block for robot description
+sem_t *gp_sem;                          //semaphore used as a mutex on the gamepad
+sem_t *rd_sem;                          //semaphore used as a mutex on the robot description
+
+// ******************************************** HELPER FUNCTIONS ****************************************** //
+
+static void error (char *msg)
+{
+	perror(msg);
+	log_runtime(ERROR, msg); //send the message to the logger
+	exit(1);
+}
+
+// ************************************ PUBLIC UTILITY FUNCTIONS ****************************************** //
+
+void print_robot_desc ()
+{
+	//since there's no get_robot_desc function (we don't need it, and hides the implementation from users)
+	//we need to acquire the semaphore for the print
+	
+	//wait on rd_sem
+	if (sem_wait(rd_sem) == -1) {
+		error("sem_wait: robot_desc_mutex (in print)");
+	}
+	
+	printf("Current Robot Description:\n");
+	for (int i = 0; i < NUM_DESC_FIELDS; i++) {
+		switch (i) {
+			case STATE:
+				printf("\tSTATE = %s\n", (rd_ptr->fields[STATE] == ERROR) ? "ERROR" : "NOMINAL");
+				break;
+			case RUN_MODE:
+				printf("\tRUN_MODE = %s\n", (rd_ptr->fields[RUN_MODE] == IDLE) ? "IDLE" : ((rd_ptr->fields[RUN_MODE] == AUTO) ? "AUTO" : "TELEOP"));
+				break;
+			case DAWN:
+				printf("\tDAWN = %s\n", (rd_ptr->fields[DAWN] == CONNECTED) ? "CONNECTED" : "DISCONNECTED");
+				break;
+			case SHEPHERD:
+				printf("\tSHEPHERD = %s\n", (rd_ptr->fields[SHEPHERD] == CONNECTED) ? "CONNECTED" : "DISCONNECTED");
+				break;
+			case GAMEPAD:
+				printf("\tGAMEPAD = %s\n", (rd_ptr->fields[GAMEPAD] == CONNECTED) ? "CONNECTED" : "DISCONNECTED");
+				break;
+			case TEAM:
+				printf("\tTEAM = %s\n", (rd_ptr->fields[TEAM] == BLUE) ? "BLUE" : "GOLD");
+				break;
+			default:
+				printf("unknown field\n");
+		}
+	}
+	printf("\n");
+	fflush(stdout);
+	
+	//release rd_sem
+	if (sem_post(rd_sem) == -1) {
+		error("sem_post: robot_desc_mutex (in print)");
+	}
+}
+
+void print_gamepad_state ()
+{
+	//since there's no get_gamepad function (we don't need it, and hides the implementation from users)
+	//we need to acquire the semaphore for the print
+	
+	//oof string arrays for printing
+	char *button_names[NUM_GAMEPAD_BUTTONS] = {
+		"A_BUTTON", "B_BUTTON", "X_BUTTON", "Y_BUTTON", "L_BUMPER", "R_BUMPER", "L_TRIGGER", "R_TRIGGER",
+		"BACK_BUTTON", "START_BUTTON", "L_STICK", "R_STICK", "UP_DPAD", "DOWN_DPAD", "LEFT_DPAD", "RIGHT_DPAD", "XBOX_BUTTON"
+	};
+	char *joystick_names[4] = {
+		"X_LEFT_JOYSTICK", "Y_LEFT_JOYSTICK", "X_RIGHT_JOYSTICK", "Y_RIGHT_JOYSTICK"
+	};
+	
+	//wait on gp_sem
+	if (sem_wait(gp_sem) == -1) {
+		error("sem_wait: gamepad_mutex (in print)");
+	}
+	
+	//only print pushed buttons (so we don't print out 22 lines of output each time we all this function)
+	printf("Current Gamepad State:\n");
+	for (int i = 0; i < NUM_GAMEPAD_BUTTONS; i++) {
+		if (gp->buttons & (1 << i)) {
+			printf("\t%s  ", button_names[i]);
+		}
+		printf("\n");
+	}
+	//print joystick positions
+	for (int i = 0; i < 4; i++) {
+		printf("\t %s = %f\n", joystick_names[i], gp->joysticks[i]);
+	}
+	printf("\n");
+	fflush(stdout);
+	
+	//release rd_sem
+	if (sem_post(gp_sem) == -1) {
+		error("sem_post: gamepad_mutex (in print)");
+	}
+}
+
+// ************************************ PUBLIC WRAPPER FUNCTIONS ****************************************** //
+
+/*
+Call this function from every process that wants to use the auxiliary shared memory wrapper
+Should be called before any other action happens
+The network handler process is responsible for initializing the shared memory blocks
+	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
+		being called from
+No return value.
+*/
+void shm_aux_init (process_t process)
+{
+	int fd_shm; //file descriptor of the memory-mapped shared memory
+	char sname[SNAME_SIZE]; //for holding semaphore names
+	
+	if (process == NET_HANDLER) {
+		
+		//mutual exclusion semaphore, gp_sem with initial value = 0
+		if ((gp_sem = sem_open(GP_MUTEX_NAME, O_CREAT, 0660, 0)) == SEM_FAILED) {
+			error("sem_open: gamepad_mutex@net_handler");
+		}
+		
+		//mutual exclusion semaphore, rd_sem with initial value = 1
+		if ((rd_sem = sem_open(RD_MUTEX_NAME, O_CREAT, 0660, 1)) == SEM_FAILED) {
+			error("sem_open: robot_desc_mutex@net_handler");
+		}
+		
+		//create gamepad shm block
+		if ((fd_shm = shm_open(GPAD_SHM_NAME, O_RDWR | O_CREAT, 0660)) == -1) {
+			error("shm_open gamepad_shm: @net_handler");
+		}
+		if (ftruncate(fd_shm, sizeof(gamepad_t)) == -1) {
+			error("ftruncate gamepad_shm: @net_handler");
+		}
+		if ((gp_ptr = mmap(NULL, sizeof(gamepad_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd_shm, 0)) == MAP_FAILED) {
+			error("mmap gamepad_shm: @net_handler");
+		}
+		if (close(fd_shm) == -1) {
+			error("close gamepad_shm: @net_handler");
+		}
+		
+		//create robot description shm block
+		if ((fd_shm = shm_open(ROBOT_DESC_SHM_NAME, O_RDWR | O_CREAT, 0660)) == -1) {
+			error("shm_open robot_desc_shm: @net_handler");
+		}
+		if (ftruncate(fd_shm, sizeof(robot_desc_t)) == -1) {
+			error("ftruncate robot_desc_shm: @net_handler");
+		}
+		if ((rd_ptr = mmap(NULL, sizeof(robot_desc_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd_shm, 0)) == MAP_FAILED) {
+			error("mmap robot_desc_shm: @net_handler");
+		}
+		if (close(fd_shm) == -1) {
+			error("close robot_desc_shm: @net_handler");
+		}
+		
+		//initialize everything
+		gp_ptr->buttons = 0;
+		for (int i = 0; i < 4; i++) {
+			gp_ptr->joysticks[i] = 0.0;
+		}
+		rd_ptr->fields[STATE] = NOMINAL;
+		rd_ptr->fields[RUN_MODE] = IDLE;
+		rd_ptr->fields[DAWN] = DISCONNECTED;
+		rd_ptr->fields[SHEPHERD] = DISCONNECTED;
+		rd_ptr->fields[GAMEPAD] = DISCONNECTED;
+		rd_ptr->fields[TEAM] = BLUE; //arbitrary
+		
+		//initialization complete; set catalog_mutex to 1 indicating shm segment available for client(s)
+		if (sem_post(gp_sem) == -1) {
+			error("sem_post: gamepad_mutex@net_handler");
+		}
+	} else {
+		//mutual exclusion semaphore, gamepad_sem
+		if ((gp_sem = sem_open(GP_MUTEX_NAME, 0, 0, 0)) == SEM_FAILED) {
+			error("sem_open: gamepad_mutex@client");
+		}
+		
+		//mutual exclusion semaphore, rd_sem
+		if ((rd_sem = sem_open(RD_MUTEX_NAME, 0, 0, 0)) == SEM_FAILED) {
+			error("sem_open: robot_desc_mutex@client");
+		}
+		
+		
+		//open gamepad shm block and map to client process virtual memory
+		if ((fd_shm = shm_open(GPAD_SHM_NAME, O_RDWR, 0)) == -1) { //no O_CREAT
+			error("shm_open: @client");
+		}
+		if ((gp_ptr = mmap(NULL, sizeof(gamepad_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd_shm, 0)) == MAP_FAILED) {
+			error("mmap: @client");
+		}
+		if (close(fd_shm) == -1) {
+			error("close: @client");
+		}
+		
+		//open robot desc shm block and map to client process virtual memory
+		if ((fd_shm = shm_open(ROBOT_DESC_SHM_NAME, O_RDWR, 0)) == -1) { //no O_CREAT
+			error("shm_open: @client");
+		}
+		if ((rd_ptr = mmap(NULL, sizeof(robot_desc_t), PROT_READ | PROT_WRITE, MAP_SHARED, fd_shm, 0)) == MAP_FAILED) {
+			error("mmap: @client");
+		}
+		if (close(fd_shm) == -1) {
+			error("close: @client");
+		}
+	}
+}
+
+/*
+Call this function if process no longer wishes to connect to auxiliary shared memory wrapper
+No other actions will work after this function is called
+Newtork handler is responsible for marking shared memory blocks and semaphores for destruction after all detach
+	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
+		being called from
+No return value.
+*/
+void shm_aux_stop (process_t process)
+{
+	char sname[SNAME_SIZE]; //holding semaphore names
+	
+	//unmap the gamepad and robot desc shm blocks
+	if (munmap(gp_ptr, sizeof(gamepad_t)) == -1) {
+		(process == NET_HANDLER) ? error("munmap: @net_handler") : error("munmap: @client");
+	}
+	if (munmap(rd_ptr, sizeof(robot_desc_t)) == -1) {
+		(process == NET_HANDLER) ? error("munmap: @net_handler") : error("munmap: @client");
+	}
+	
+	//close both semaphores
+	if (sem_close(gp_sem) == -1) {
+		(process == NET_HANDLER) ? error("sem_close: gamepad_mutex@net_handler") : error("sem_close: gamepad_mutex@client");
+	}
+	if (sem_close(rd_sem) == -1) {
+		(process == NET_HANDLER) ? error("sem_close: robot_desc_mutex@net_handler") : error("sem_close: robot_desc_mutex@client");
+	}
+	
+	//the network handler is also responsible for unlinking everything
+	if (process == NET_HANDLER) {
+		//unlink shared memory blocks
+		if (shm_unlink(GPAD_SHM_NAME) == -1) {
+			error("shm_unlink");
+		}
+		if (shm_unlink(ROBOT_DESC_SHM_NAME) == -1) {
+			error("shm_unlink");
+		}
+		
+		//unlink semaphores
+		if (sem_unlink(GP_MUTEX_NAME) == -1) {
+			error("sem_unlink: gamepad_mutex");
+		}
+		if (sem_unlink(RD_MUTEX_NAME) == -1) {
+			error("sem_unlink: robot_desc_mutex");
+		}
+	}
+}
+
+/*
+This function writes the specified value into the specified field.
+Blocks on the robot description semaphore.
+	- field: one of the robot_desc_val_t's defined above to write val to
+	- val: one of the robot_desc_vals defined above to write to the specified field
+No return value.
+*/
+void robot_desc_write (robot_desc_field_t field, robot_desc_val_t val);
+{
+	//wait on rd_sem
+	if (sem_wait(rd_sem) == -1) {
+		error("sem_wait: robot_desc_mutex");
+	}
+	
+	//write the val into the field
+	rd_ptr->fields[FIELD] = val;
+	
+	//release rd_sem
+	if (sem_post(rd_sem) == -1) {
+		error("sem_post: robot_desc_mutex");
+	}
+}
+
+/*
+This function reads the specified field.
+Blocks on the robot description semaphore.
+	- field: one of the robot_desc_val_t's defined above to read from
+Returns one of the robot_desc_val_t's defined above that is the current value of that field.
+*/
+robot_desc_val_t robot_desc_read (robot_desc_field_t field)
+{
+	robot_desc_val_t ret;
+	
+	//wait on rd_sem
+	if (sem_wait(rd_sem) == -1) {
+		error("sem_wait: robot_desc_mutex");
+	}
+	
+	ret = rd_ptr->fields[FIELD];
+	
+	//release rd_sem
+	if (sem_post(rd_sem) == -1) {
+		error("sem_post: robot_desc_mutex");
+	}
+	
+	return ret;
+}
+
+/*
+This function writes the given state of the gamepad to shared memory.
+Blocks on both the gamepad semaphore and device description semaphore (to check if gamepad connected).
+	- pressed_buttons: a 32-bit bitmap that corresponds to which buttons are currently pressed
+		(only the first NUM_GAMEPAD_BUTTONS bits used, since there are NUM_GAMEPAD_BUTTONS buttons)
+	- joystick_vals: array of 4 floats that contain the values to write to the joystick
+No return value.
+*/
+void gamepad_write (uint32_t pressed_buttons, float *joystick_vals)
+{
+	//wait on rd_sem
+	if (sem_wait(rd_sem) == -1) {
+		error("sem_wait: robot_desc_mutex");
+	}
+	
+	//if no gamepad connected, then release rd_sem and return
+	if (robot_desc_read(GAMEPAD) == DISCONNECTED) {
+		log_runtime(WARN, "tried to write, but no gamepad connected");
+		if (sem_post(rd_sem) == -1) {
+			error("sem_post: robot_desc_mutex");
+		}
+		return;
+	}
+	
+	//release rd_sem
+	if (sem_post(rd_sem) == -1) {
+		error("sem_post: robot_desc_mutex");
+	}
+	
+	//wait on gp_sem
+	if (sem_wait(gp_sem) == -1) {
+		error("sem_wait: gamepad_mutex");
+	}
+	
+	gp_ptr->buttons = pressed_buttons;
+	for (int i = 0; i < 4; i++) {
+		gp_ptr->joysticks[i] = joystick_vals[i];
+	}
+	
+	//release gp_sem
+	if (sem_post(gp_sem) == -1) {
+		error("sem_post: gamepad_mutex");
+	}
+}
+
+/*
+This function reads the current state of the gamepad to the provided pointers.
+Blocks on both the gamepad semaphore and device description semaphore (to check if gamepad connected).
+	- pressed_buttons: pointer to 32-bit bitmap to which the current button bitmap state will be read into
+	- joystick_vals: array of 4 floats to which the current joystick states will be read into
+No return value.
+*/
+void gamepad_read (uint32_t &pressed_buttons, float *joystick_vals)
+{
+	//wait on rd_sem
+	if (sem_wait(rd_sem) == -1) {
+		error("sem_wait: robot_desc_mutex");
+	}
+	
+	//if no gamepad connected, then release rd_sem and return
+	if (robot_desc_read(GAMEPAD) == DISCONNECTED) {
+		log_runtime(WARN, "tried to read, but no gamepad connected");
+		if (sem_post(rd_sem) == -1) {
+			error("sem_post: robot_desc_mutex");
+		}
+		return;
+	}
+	
+	//release rd_sem
+	if (sem_post(rd_sem) == -1) {
+		error("sem_post: robot_desc_mutex");
+	}
+	
+	//wait on gp_sem
+	if (sem_wait(gp_sem) == -1) {
+		error("sem_wait: gamepad_mutex");
+	}
+	
+	*pressed_buttons = gp_ptr->buttons;
+	for (int i = 0; i < 4; i++) {
+		joystick_vals[i] = gp_ptr->joysticks[i];
+	}
+	
+	//release gp_sem
+	if (sem_post(gp_sem) == -1) {
+		error("sem_post: gamepad_mutex");
+	}
+}

--- a/shm_wrapper_aux/shm_wrapper_aux.h
+++ b/shm_wrapper_aux/shm_wrapper_aux.h
@@ -14,33 +14,6 @@
 #include "../logger/logger.h"              //for logger (TODO: consider removing relative pathname in include)
 #include "../runtime_util/runtime_util.h"  //for runtime constants (TODO: consider removing relative pathname in include)
 
-#define NUM_DESC_FIELDS 6                   //number of fields in the robot description
-#define NUM_GAMEPAD_BUTTONS 17              //number of gamepad buttons
-
-//enumerated names for the buttons on the gamepad
-typedef enum gp_buttons {
-	A_BUTTON, B_BUTTON, X_BUTTON, Y_BUTTON, L_BUMPER, R_BUMPER, L_TRIGGER, R_TRIGGER,
-	BACK_BUTTON, START_BUTTON, L_STICK, R_STICK, UP_DPAD, DOWN_DPAD, LEFT_DPAD, RIGHT_DPAD, XBOX_BUTTON
-} gp_button_t;
-
-//enumerated names for the joystick params of the gamepad
-typedef enum gp_joysticks {
-	X_LEFT_JOYSTICK, Y_LEFT_JOYSTICK, X_RIGHT_JOYSTICK, Y_RIGHT_JOYSTICK
-} gp_joystick_t;
-
-//enumerated names for the different values the robot description fields can take on
-typedef enum robot_desc_vals {
-	ISSUE, NOMINAL,             //values for robot.state
-	IDLE, AUTO, TELEOP,         //values for robot.run_mode
-	CONNECTED, DISCONNECTED,    //values for robot.dawn, robot.shepherd, robot.gamepad
-	BLUE, GOLD                  //values for robot.team
-} robot_desc_val_t;
-
-//enumerated names for the fields in the robot description
-typedef enum robot_descs {
-	STATE, RUN_MODE, DAWN, SHEPHERD, GAMEPAD, TEAM
-} robot_desc_field_t;
-
 // ******************************************* UTILITY FUNCTIONS ****************************************** //
 
 void print_robot_desc ();

--- a/shm_wrapper_aux/shm_wrapper_aux.h
+++ b/shm_wrapper_aux/shm_wrapper_aux.h
@@ -4,6 +4,7 @@
 #include <stdio.h>                         //for i/o
 #include <stdlib.h>                        //for standard utility functions (exit, sleep)
 #include <stdint.h>						   //for standard integer types
+#include <sys/time.h>                      //for measuring time
 #include <sys/types.h>                     //for sem_t and other standard system types
 #include <sys/stat.h>                      //for some of the flags that are used (the mode constants)
 #include <fcntl.h>                         //for flags used for opening and closing files (O_* constants)
@@ -66,21 +67,34 @@ No return value.
 void shm_aux_stop (process_t process);
 
 /*
+This function reads the specified field.
+Blocks on the robot description semaphore.
+	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
+		being called from
+	- field: one of the robot_desc_val_t's defined above to read from
+Returns one of the robot_desc_val_t's defined above that is the current value of that field.
+*/
+robot_desc_val_t robot_desc_read (process_t process, robot_desc_field_t field);
+
+/*
 This function writes the specified value into the specified field.
 Blocks on the robot description semaphore.
+	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
+		being called from
 	- field: one of the robot_desc_val_t's defined above to write val to
 	- val: one of the robot_desc_vals defined above to write to the specified field
 No return value.
 */
-void robot_desc_write (robot_desc_field_t field, robot_desc_val_t val);
+void robot_desc_write (process_t process, robot_desc_field_t field, robot_desc_val_t val);
 
 /*
-This function reads the specified field.
-Blocks on the robot description semaphore.
-	- field: one of the robot_desc_val_t's defined above to read from
-Returns one of the robot_desc_val_t's defined above that is the current value of that field.
+This function reads the current state of the gamepad to the provided pointers.
+Blocks on both the gamepad semaphore and device description semaphore (to check if gamepad connected).
+	- pressed_buttons: pointer to 32-bit bitmap to which the current button bitmap state will be read into
+	- joystick_vals: array of 4 floats to which the current joystick states will be read into
+No return value.
 */
-robot_desc_val_t robot_desc_read (robot_desc_field_t field);
+void gamepad_read (uint32_t &pressed_buttons, float *joystick_vals);
 
 /*
 This function writes the given state of the gamepad to shared memory.
@@ -91,14 +105,5 @@ Blocks on both the gamepad semaphore and device description semaphore (to check 
 No return value.
 */
 void gamepad_write (uint32_t pressed_buttons, float *joystick_vals);
-
-/*
-This function reads the current state of the gamepad to the provided pointers.
-Blocks on both the gamepad semaphore and device description semaphore (to check if gamepad connected).
-	- pressed_buttons: pointer to 32-bit bitmap to which the current button bitmap state will be read into
-	- joystick_vals: array of 4 floats to which the current joystick states will be read into
-No return value.
-*/
-void gamepad_read (uint32_t &pressed_buttons, float *joystick_vals);
 
 #endif

--- a/shm_wrapper_aux/shm_wrapper_aux.h
+++ b/shm_wrapper_aux/shm_wrapper_aux.h
@@ -14,6 +14,9 @@
 #include "../logger/logger.h"              //for logger (TODO: consider removing relative pathname in include)
 #include "../runtime_util/runtime_util.h"  //for runtime constants (TODO: consider removing relative pathname in include)
 
+#define NUM_DESC_FIELDS 6                   //number of fields in the robot description
+#define NUM_GAMEPAD_BUTTONS 17              //number of gamepad buttons
+
 //enumerated names for the buttons on the gamepad
 typedef enum gp_buttons {
 	A_BUTTON, B_BUTTON, X_BUTTON, Y_BUTTON, L_BUMPER, R_BUMPER, L_TRIGGER, R_TRIGGER,
@@ -27,7 +30,7 @@ typedef enum gp_joysticks {
 
 //enumerated names for the different values the robot description fields can take on
 typedef enum robot_desc_vals {
-	ERROR, NOMINAL,             //values for robot.state
+	ISSUE, NOMINAL,             //values for robot.state
 	IDLE, AUTO, TELEOP,         //values for robot.run_mode
 	CONNECTED, DISCONNECTED,    //values for robot.dawn, robot.shepherd, robot.gamepad
 	BLUE, GOLD                  //values for robot.team
@@ -94,7 +97,7 @@ Blocks on both the gamepad semaphore and device description semaphore (to check 
 	- joystick_vals: array of 4 floats to which the current joystick states will be read into
 No return value.
 */
-void gamepad_read (uint32_t &pressed_buttons, float *joystick_vals);
+void gamepad_read (process_t process, uint32_t *pressed_buttons, float *joystick_vals);
 
 /*
 This function writes the given state of the gamepad to shared memory.
@@ -104,6 +107,6 @@ Blocks on both the gamepad semaphore and device description semaphore (to check 
 	- joystick_vals: array of 4 floats that contain the values to write to the joystick
 No return value.
 */
-void gamepad_write (uint32_t pressed_buttons, float *joystick_vals);
+void gamepad_write (process_t process, uint32_t pressed_buttons, float *joystick_vals);
 
 #endif

--- a/shm_wrapper_aux/shm_wrapper_aux.h
+++ b/shm_wrapper_aux/shm_wrapper_aux.h
@@ -45,23 +45,19 @@ void shm_aux_stop (process_t process);
 /*
 This function reads the specified field.
 Blocks on the robot description semaphore.
-	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
-		being called from
 	- field: one of the robot_desc_val_t's defined above to read from
 Returns one of the robot_desc_val_t's defined above that is the current value of that field.
 */
-robot_desc_val_t robot_desc_read (process_t process, robot_desc_field_t field);
+robot_desc_val_t robot_desc_read (robot_desc_field_t field);
 
 /*
 This function writes the specified value into the specified field.
 Blocks on the robot description semaphore.
-	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
-		being called from
 	- field: one of the robot_desc_val_t's defined above to write val to
 	- val: one of the robot_desc_vals defined above to write to the specified field
 No return value.
 */
-void robot_desc_write (process_t process, robot_desc_field_t field, robot_desc_val_t val);
+void robot_desc_write (robot_desc_field_t field, robot_desc_val_t val);
 
 /*
 This function reads the current state of the gamepad to the provided pointers.

--- a/shm_wrapper_aux/shm_wrapper_aux.h
+++ b/shm_wrapper_aux/shm_wrapper_aux.h
@@ -1,0 +1,104 @@
+#ifndef SHM_WRAPPER_AUX_H
+#define SHM_WRAPPER_AUX_H
+
+#include <stdio.h>                         //for i/o
+#include <stdlib.h>                        //for standard utility functions (exit, sleep)
+#include <stdint.h>						   //for standard integer types
+#include <sys/types.h>                     //for sem_t and other standard system types
+#include <sys/stat.h>                      //for some of the flags that are used (the mode constants)
+#include <fcntl.h>                         //for flags used for opening and closing files (O_* constants)
+#include <unistd.h>                        //for standard symbolic constants
+#include <semaphore.h>                     //for semaphores
+#include <sys/mman.h>                      //for posix shared memory
+#include "../logger/logger.h"              //for logger (TODO: consider removing relative pathname in include)
+#include "../runtime_util/runtime_util.h"  //for runtime constants (TODO: consider removing relative pathname in include)
+
+//enumerated names for the buttons on the gamepad
+typedef enum gp_buttons {
+	A_BUTTON, B_BUTTON, X_BUTTON, Y_BUTTON, L_BUMPER, R_BUMPER, L_TRIGGER, R_TRIGGER,
+	BACK_BUTTON, START_BUTTON, L_STICK, R_STICK, UP_DPAD, DOWN_DPAD, LEFT_DPAD, RIGHT_DPAD, XBOX_BUTTON
+} gp_button_t;
+
+//enumerated names for the joystick params of the gamepad
+typedef enum gp_joysticks {
+	X_LEFT_JOYSTICK, Y_LEFT_JOYSTICK, X_RIGHT_JOYSTICK, Y_RIGHT_JOYSTICK
+} gp_joystick_t;
+
+//enumerated names for the different values the robot description fields can take on
+typedef enum robot_desc_vals {
+	ERROR, NOMINAL,             //values for robot.state
+	IDLE, AUTO, TELEOP,         //values for robot.run_mode
+	CONNECTED, DISCONNECTED,    //values for robot.dawn, robot.shepherd, robot.gamepad
+	BLUE, GOLD                  //values for robot.team
+} robot_desc_val_t;
+
+//enumerated names for the fields in the robot description
+typedef enum robot_descs {
+	STATE, RUN_MODE, DAWN, SHEPHERD, GAMEPAD, TEAM
+} robot_desc_field_t;
+
+// ******************************************* UTILITY FUNCTIONS ****************************************** //
+
+void print_robot_desc ();
+
+void print_gamepad_state ();
+
+// ******************************************* WRAPPER FUNCTIONS ****************************************** //
+
+/*
+Call this function from every process that wants to use the auxiliary shared memory wrapper
+Should be called before any other action happens
+The network handler process is responsible for initializing the shared memory blocks
+	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
+		being called from
+No return value.
+*/
+void shm_aux_init (process_t process);
+
+/*
+Call this function if process no longer wishes to connect to auxiliary shared memory wrapper
+No other actions will work after this function is called
+Newtork handler is responsible for marking shared memory blocks and semaphores for destruction after all detach
+	- process: one of DEV_HANDLER, EXECUTOR, NET_HANDLER to specify which process this function is
+		being called from
+No return value.
+*/
+void shm_aux_stop (process_t process);
+
+/*
+This function writes the specified value into the specified field.
+Blocks on the robot description semaphore.
+	- field: one of the robot_desc_val_t's defined above to write val to
+	- val: one of the robot_desc_vals defined above to write to the specified field
+No return value.
+*/
+void robot_desc_write (robot_desc_field_t field, robot_desc_val_t val);
+
+/*
+This function reads the specified field.
+Blocks on the robot description semaphore.
+	- field: one of the robot_desc_val_t's defined above to read from
+Returns one of the robot_desc_val_t's defined above that is the current value of that field.
+*/
+robot_desc_val_t robot_desc_read (robot_desc_field_t field);
+
+/*
+This function writes the given state of the gamepad to shared memory.
+Blocks on both the gamepad semaphore and device description semaphore (to check if gamepad connected).
+	- pressed_buttons: a 32-bit bitmap that corresponds to which buttons are currently pressed
+		(only the first 17 bits used, since there are 17 buttons)
+	- joystick_vals: array of 4 floats that contain the values to write to the joystick
+No return value.
+*/
+void gamepad_write (uint32_t pressed_buttons, float *joystick_vals);
+
+/*
+This function reads the current state of the gamepad to the provided pointers.
+Blocks on both the gamepad semaphore and device description semaphore (to check if gamepad connected).
+	- pressed_buttons: pointer to 32-bit bitmap to which the current button bitmap state will be read into
+	- joystick_vals: array of 4 floats to which the current joystick states will be read into
+No return value.
+*/
+void gamepad_read (uint32_t &pressed_buttons, float *joystick_vals);
+
+#endif

--- a/shm_wrapper_aux/shm_wrapper_aux_test1.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test1.c
@@ -86,69 +86,44 @@ void sanity_robot_desc_test ()
 	
 	printf("Begin sanity robot desc test...\n");
 	
-	for (int i = 0; i < 13; i++) {
+	for (int i = 0; i < 11; i++) {
 		switch (i) {
 			case 0:
-				robot_desc_write(NET_HANDLER, STATE, ISSUE);
+				robot_desc_write(RUN_MODE, AUTO);
 				break;
 			case 1:
-				robot_desc_write(NET_HANDLER, RUN_MODE, AUTO);
+				robot_desc_write(RUN_MODE, TELEOP);
 				break;
 			case 2:
-				robot_desc_write(NET_HANDLER, RUN_MODE, TELEOP);
+				robot_desc_write(DAWN, CONNECTED);
 				break;
 			case 3:
-				robot_desc_write(NET_HANDLER, DAWN, CONNECTED);
+				robot_desc_write(DAWN, DISCONNECTED);
 				break;
 			case 4:
-				robot_desc_write(NET_HANDLER, DAWN, DISCONNECTED);
+				robot_desc_write(SHEPHERD, CONNECTED);
 				break;
 			case 5:
-				robot_desc_write(NET_HANDLER, SHEPHERD, CONNECTED);
+				robot_desc_write(SHEPHERD, DISCONNECTED);
 				break;
 			case 6:
-				robot_desc_write(NET_HANDLER, SHEPHERD, DISCONNECTED);
+				robot_desc_write(GAMEPAD, DISCONNECTED);
 				break;
 			case 7:
-				robot_desc_write(NET_HANDLER, GAMEPAD, DISCONNECTED);
+				robot_desc_write(GAMEPAD, CONNECTED);
 				break;
 			case 8:
-				robot_desc_write(NET_HANDLER, GAMEPAD, CONNECTED);
+				robot_desc_write(TEAM, GOLD);
 				break;
 			case 9:
-				robot_desc_write(NET_HANDLER, TEAM, GOLD);
+				robot_desc_write(TEAM, BLUE);
 				break;
 			case 10:
-				robot_desc_write(NET_HANDLER, TEAM, BLUE);
-				break;
-			case 11:
-				robot_desc_write(NET_HANDLER, STATE, NOMINAL);
-				break;
-			case 12:
-				robot_desc_write(NET_HANDLER, RUN_MODE, IDLE);
+				robot_desc_write(RUN_MODE, IDLE);
 				break;
 		}
 		usleep(200000); //sleep for 0.2 sec
 	}
-	printf("Done!\n\n");
-}
-
-// *************************************************************************************************** //
-//robot description write override test
-void robot_desc_override_test ()
-{
-	sync();
-	
-	printf("Begin robot desc override test...\n");
-	
-	//this should take about 1 sec because it blocks every time
-	//should also output a logger message
-	robot_desc_write(NET_HANDLER, RUN_MODE, AUTO);
-	robot_desc_write(NET_HANDLER, RUN_MODE, TELEOP);
-	robot_desc_write(NET_HANDLER, TEAM, GOLD);
-	robot_desc_write(NET_HANDLER, TEAM, BLUE);
-	robot_desc_write(NET_HANDLER, RUN_MODE, IDLE);
-	
 	printf("Done!\n\n");
 }
 
@@ -168,14 +143,12 @@ int main()
 	shm_aux_init(NET_HANDLER);
 	logger_init(NET_HANDLER);
 	signal(SIGINT, ctrl_c_handler); //hopefully fails gracefully when pressing Ctrl-C in the terminal
-	robot_desc_write(NET_HANDLER, GAMEPAD, CONNECTED);
+	robot_desc_write(GAMEPAD, CONNECTED);
 	print_robot_desc();
 	
 	sanity_gamepad_test();
 	
 	sanity_robot_desc_test();
-	
-	robot_desc_override_test();
 	
 	sleep(2);
 	

--- a/shm_wrapper_aux/shm_wrapper_aux_test1.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test1.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <signal.h>
+#include "shm_wrapper_aux.h"
+#include "../logger/logger.h"
+#include "../runtime_util/runtime_util.h"     //(TODO: consider removing relative pathnames)
+
+//test process 1 for shm_wrapper_aux. is a dummy net_handler
+
+//sanity gamepad test
+
+//sanity robot description test
+
+//robot description write override test
+
+// *************************************************************************************************** //
+
+void ctrl_c_handler (int sig_num)
+{
+	printf("Aborting and cleaning up\n");
+	fflush(stdout);
+	shm_aux_stop(NET_HANDLER);
+	logger_stop(NET_HANDLER);
+	exit(1);
+}
+
+int main()
+{
+	shm_aux_init(NET_HANDLER);
+	logger_init(NET_HANDLER);
+	signal(SIGINT, ctrl_c_handler); //hopefully fails gracefully when pressing Ctrl-C in the terminal
+	
+	sanity_test();
+	
+	sleep(2);
+	
+	shm_aux_stop(NET_HANDLER);
+	logger_stop(NET_HANDLER);
+	
+	return 0;
+}

--- a/shm_wrapper_aux/shm_wrapper_aux_test1.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test1.c
@@ -9,11 +9,148 @@
 
 //test process 1 for shm_wrapper_aux. is a dummy net_handler
 
+// *************************************************************************************************** //
+void sync ()
+{
+	uint32_t buttons;
+	float joystick_vals[4];
+
+	//write a 1 to a_button
+	gamepad_read(NET_HANDLER, &buttons, joystick_vals);
+	gamepad_write(NET_HANDLER, buttons | 1, joystick_vals);
+	
+	//wait for a 1 on b_button
+	while (1) {
+		gamepad_read(NET_HANDLER, &buttons, joystick_vals);
+		if (buttons & 2) {
+			break;
+		}
+		usleep(1000);
+	}
+	sleep(1);
+	gamepad_write(NET_HANDLER, 0, joystick_vals);
+	sleep(1);
+	printf("\tSynced; starting test!\n");
+}
+
+// *************************************************************************************************** //
 //sanity gamepad test
+void sanity_gamepad_test ()
+{
+	uint32_t buttons;
+	float joystick_vals[4];
+	
+	sync();
+	
+	printf("Begin sanity gamepad test...\n");
+	
+	buttons = 34788240; //push some random buttons
+	joystick_vals[X_LEFT_JOYSTICK] = -0.4854;
+	joystick_vals[Y_LEFT_JOYSTICK] = 0.58989;
+	joystick_vals[X_RIGHT_JOYSTICK] = 0.9898;
+	joystick_vals[Y_RIGHT_JOYSTICK] = -0.776;
+	
+	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	print_gamepad_state();
+	sleep(1);
+	
+	buttons = 0; //no buttons pushed
+	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	print_gamepad_state();
+	sleep(1);
+	
+	buttons = 789597848; //push smoe different random buttons
+	joystick_vals[X_LEFT_JOYSTICK] = -0.9489;
+	joystick_vals[Y_LEFT_JOYSTICK] = 0.0;
+	joystick_vals[X_RIGHT_JOYSTICK] = 1.0;
+	joystick_vals[Y_RIGHT_JOYSTICK] = -1.0;
+	
+	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	print_gamepad_state();
+	sleep(1);
+	
+	buttons = 0;
+	for (int i = 0; i < 4; i++) {
+		joystick_vals[i] = 0.0;
+	}
+	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	print_gamepad_state();
+	printf("Done!\n\n");
+}
 
+// *************************************************************************************************** //
 //sanity robot description test
+void sanity_robot_desc_test ()
+{
+	sync();
+	
+	printf("Begin sanity robot desc test...\n");
+	
+	for (int i = 0; i < 13; i++) {
+		switch (i) {
+			case 0:
+				robot_desc_write(NET_HANDLER, STATE, ISSUE);
+				break;
+			case 1:
+				robot_desc_write(NET_HANDLER, RUN_MODE, AUTO);
+				break;
+			case 2:
+				robot_desc_write(NET_HANDLER, RUN_MODE, TELEOP);
+				break;
+			case 3:
+				robot_desc_write(NET_HANDLER, DAWN, CONNECTED);
+				break;
+			case 4:
+				robot_desc_write(NET_HANDLER, DAWN, DISCONNECTED);
+				break;
+			case 5:
+				robot_desc_write(NET_HANDLER, SHEPHERD, CONNECTED);
+				break;
+			case 6:
+				robot_desc_write(NET_HANDLER, SHEPHERD, DISCONNECTED);
+				break;
+			case 7:
+				robot_desc_write(NET_HANDLER, GAMEPAD, DISCONNECTED);
+				break;
+			case 8:
+				robot_desc_write(NET_HANDLER, GAMEPAD, CONNECTED);
+				break;
+			case 9:
+				robot_desc_write(NET_HANDLER, TEAM, GOLD);
+				break;
+			case 10:
+				robot_desc_write(NET_HANDLER, TEAM, BLUE);
+				break;
+			case 11:
+				robot_desc_write(NET_HANDLER, STATE, NOMINAL);
+				break;
+			case 12:
+				robot_desc_write(NET_HANDLER, RUN_MODE, IDLE);
+				break;
+		}
+		usleep(200000); //sleep for 0.2 sec
+	}
+	printf("Done!\n\n");
+}
 
+// *************************************************************************************************** //
 //robot description write override test
+void robot_desc_override_test ()
+{
+	sync();
+	
+	printf("Begin robot desc override test...\n");
+	
+	//this should take about 1 sec because it blocks every time
+	//should also output a logger message
+	robot_desc_write(NET_HANDLER, RUN_MODE, AUTO);
+	robot_desc_write(NET_HANDLER, RUN_MODE, TELEOP);
+	robot_desc_write(NET_HANDLER, TEAM, GOLD);
+	robot_desc_write(NET_HANDLER, TEAM, BLUE);
+	robot_desc_write(NET_HANDLER, RUN_MODE, IDLE);
+	
+	printf("Done!\n\n");
+}
 
 // *************************************************************************************************** //
 
@@ -31,8 +168,14 @@ int main()
 	shm_aux_init(NET_HANDLER);
 	logger_init(NET_HANDLER);
 	signal(SIGINT, ctrl_c_handler); //hopefully fails gracefully when pressing Ctrl-C in the terminal
+	robot_desc_write(NET_HANDLER, GAMEPAD, CONNECTED);
+	print_robot_desc();
 	
-	sanity_test();
+	sanity_gamepad_test();
+	
+	sanity_robot_desc_test();
+	
+	robot_desc_override_test();
 	
 	sleep(2);
 	

--- a/shm_wrapper_aux/shm_wrapper_aux_test2.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test2.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <signal.h>
+#include "shm_wrapper_aux.h"
+#include "../logger/logger.h"
+#include "../runtime_util/runtime_util.h"     //(TODO: consider removing relative pathnames)
+
+//test process 2 for shm_wrapper_aux. is a dummy executor
+
+//sanity gamepad test
+
+//sanity robot description test
+
+//robot description write override test
+
+// *************************************************************************************************** //
+
+void ctrl_c_handler (int sig_num)
+{
+	printf("Aborting and cleaning up\n");
+	fflush(stdout);
+	shm_aux_stop(EXECUTOR);
+	logger_stop(EXECUTOR);
+	exit(1);
+}
+
+int main()
+{	
+	shm_aux_init(EXECUTOR);
+	logger_init(EXECUTOR);
+	signal(SIGINT, ctrl_c_handler); //hopefully fails gracefully when pressing Ctrl-C in the terminal
+	
+	sanity_test();	
+	
+	shm_aux_stop(EXECUTOR);
+	logger_stop(EXECUTOR);
+	
+	sleep(2);
+	
+	return 0;
+}

--- a/shm_wrapper_aux/shm_wrapper_aux_test2.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test2.c
@@ -59,16 +59,16 @@ void sanity_gamepad_test ()
 void sanity_robot_desc_test ()
 {
 	int count = 0;
-	robot_desc_val_t curr[6] = { NOMINAL, IDLE, DISCONNECTED, DISCONNECTED, CONNECTED, BLUE };
-	robot_desc_val_t prev[6] = { NOMINAL, IDLE, DISCONNECTED, DISCONNECTED, CONNECTED, BLUE };
+	robot_desc_val_t curr[6] = { IDLE, DISCONNECTED, DISCONNECTED, CONNECTED, BLUE };
+	robot_desc_val_t prev[6] = { IDLE, DISCONNECTED, DISCONNECTED, CONNECTED, BLUE };
 	
 	sync();
 	
 	printf("Begin sanity robot desc test...\n");
 	
-	while (count < 13) {
+	while (count < 11) {
 		for (int i = 0; i < NUM_DESC_FIELDS; i++) {
-			curr[i] = robot_desc_read(EXECUTOR, i);
+			curr[i] = robot_desc_read(i);
 			if (curr[i] != prev[i]) {
 				printf("something has changed! new robot description:\n");
 				print_robot_desc();
@@ -78,19 +78,6 @@ void sanity_robot_desc_test ()
 		}
 		usleep(100);
 	}
-	printf("Done!\n\n");
-}
-
-// *************************************************************************************************** //
-//robot description write override test
-void robot_desc_override_test ()
-{
-	sync();
-	
-	printf("Begin robot desc override test...\n");
-	
-	sleep(1); //don't read anything out!
-	
 	printf("Done!\n\n");
 }
 
@@ -113,9 +100,7 @@ int main()
 	
 	sanity_gamepad_test();
 	
-	sanity_robot_desc_test();	
-	
-	robot_desc_override_test();
+	sanity_robot_desc_test();
 	
 	shm_aux_stop(EXECUTOR);
 	logger_stop(EXECUTOR);


### PR DESCRIPTION
- Added shm_wrapper_aux and suite of tests, including printing utilities; added Makefile
- Bug fixes on the synchronization function used to execute the shm wrapper tests consistently
- Added read and write functions for the device shm wrapper that allow user to reference devices with their 64-bit unique ID number, instead of their device index
- Added a file that just spawns the maximum number of devices in their shared memory wrapper for the executor to read
- Inserted logger messages into both shared memory wrappers