### PR TITLE
[SHM_WRAPPER] minor cleanups and additions to shm wrappers

### DIFF
--- a/logger/logger.c
+++ b/logger/logger.c
@@ -38,7 +38,6 @@ void logger_init (process_t process)
 	} else if (process == NET_HANDLER) {
 		sprintf(process_str, "NET_HANDLER");
 	}
-	
 }
 
 void logger_stop ()

--- a/logger/logger.c
+++ b/logger/logger.c
@@ -37,6 +37,8 @@ void logger_init (process_t process)
 		sprintf(process_str, "EXECUTOR");
 	} else if (process == NET_HANDLER) {
 		sprintf(process_str, "NET_HANDLER");
+	} else if (process == STUDENTAPI) {
+		sprintf(process_str, "STUDENTAPI");
 	}
 }
 

--- a/logger/logger_config.h
+++ b/logger/logger_config.h
@@ -16,6 +16,6 @@ typedef enum log_output { STD_OUT, LOG_FILE, NETWORK } log_output;
 #define CURR_OUTPUT_LOC STD_OUT
 
 //define the name/location of the log file
-#define LOG_FILE_LOC "/d/Documents/CollegeWork/PiE/c-runtime/logs/test.log"
+#define LOG_FILE_LOC "/Users/ben/Desktop/runtime_log.log"
 
 #endif

--- a/runtime_util/runtime_util.h
+++ b/runtime_util/runtime_util.h
@@ -13,7 +13,7 @@
 
 //enumerate names of processes
 typedef enum process { 
-	DEV_HANDLER, EXECUTOR, NET_HANDLER 
+	DEV_HANDLER, EXECUTOR, NET_HANDLER, STUDENTAPI 
 } process_t;
 
 //enumerated names for the buttons on the gamepad

--- a/shm_wrapper_aux/shm_wrapper_aux.h
+++ b/shm_wrapper_aux/shm_wrapper_aux.h
@@ -66,7 +66,7 @@ Blocks on both the gamepad semaphore and device description semaphore (to check 
 	- joystick_vals: array of 4 floats to which the current joystick states will be read into
 No return value.
 */
-void gamepad_read (process_t process, uint32_t *pressed_buttons, float *joystick_vals);
+void gamepad_read (uint32_t *pressed_buttons, float *joystick_vals);
 
 /*
 This function writes the given state of the gamepad to shared memory.
@@ -76,6 +76,6 @@ Blocks on both the gamepad semaphore and device description semaphore (to check 
 	- joystick_vals: array of 4 floats that contain the values to write to the joystick
 No return value.
 */
-void gamepad_write (process_t process, uint32_t pressed_buttons, float *joystick_vals);
+void gamepad_write (uint32_t pressed_buttons, float *joystick_vals);
 
 #endif

--- a/shm_wrapper_aux/shm_wrapper_aux_test1.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test1.c
@@ -16,19 +16,19 @@ void sync ()
 	float joystick_vals[4];
 
 	//write a 1 to a_button
-	gamepad_read(NET_HANDLER, &buttons, joystick_vals);
-	gamepad_write(NET_HANDLER, buttons | 1, joystick_vals);
+	gamepad_read(&buttons, joystick_vals);
+	gamepad_write(buttons | 1, joystick_vals);
 	
 	//wait for a 1 on b_button
 	while (1) {
-		gamepad_read(NET_HANDLER, &buttons, joystick_vals);
+		gamepad_read(&buttons, joystick_vals);
 		if (buttons & 2) {
 			break;
 		}
 		usleep(1000);
 	}
 	sleep(1);
-	gamepad_write(NET_HANDLER, 0, joystick_vals);
+	gamepad_write(0, joystick_vals);
 	sleep(1);
 	printf("\tSynced; starting test!\n");
 }
@@ -50,12 +50,12 @@ void sanity_gamepad_test ()
 	joystick_vals[X_RIGHT_JOYSTICK] = 0.9898;
 	joystick_vals[Y_RIGHT_JOYSTICK] = -0.776;
 	
-	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	gamepad_write(buttons, joystick_vals);
 	print_gamepad_state();
 	sleep(1);
 	
 	buttons = 0; //no buttons pushed
-	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	gamepad_write(buttons, joystick_vals);
 	print_gamepad_state();
 	sleep(1);
 	
@@ -65,7 +65,7 @@ void sanity_gamepad_test ()
 	joystick_vals[X_RIGHT_JOYSTICK] = 1.0;
 	joystick_vals[Y_RIGHT_JOYSTICK] = -1.0;
 	
-	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	gamepad_write(buttons, joystick_vals);
 	print_gamepad_state();
 	sleep(1);
 	
@@ -73,7 +73,7 @@ void sanity_gamepad_test ()
 	for (int i = 0; i < 4; i++) {
 		joystick_vals[i] = 0.0;
 	}
-	gamepad_write(NET_HANDLER, buttons, joystick_vals);
+	gamepad_write(buttons, joystick_vals);
 	print_gamepad_state();
 	printf("Done!\n\n");
 }

--- a/shm_wrapper_aux/shm_wrapper_aux_test2.c
+++ b/shm_wrapper_aux/shm_wrapper_aux_test2.c
@@ -16,12 +16,12 @@ void sync ()
 	float joystick_vals[4];
 	
 	//write a 1 to b_button
-	gamepad_read(EXECUTOR, &buttons, joystick_vals);
-	gamepad_write(EXECUTOR, buttons | 2, joystick_vals);
+	gamepad_read(&buttons, joystick_vals);
+	gamepad_write(buttons | 2, joystick_vals);
 	
 	//wait on a 1 to a_button
 	while (1) {
-		gamepad_read(EXECUTOR, &buttons, joystick_vals);
+		gamepad_read(&buttons, joystick_vals);
 		if (buttons & 1) {
 			break;
 		}
@@ -43,7 +43,7 @@ void sanity_gamepad_test ()
 	printf("Begin sanity gamepad test...\n");
 	
 	for (int i = 0; i < 7; i++) {
-		gamepad_read(EXECUTOR, &buttons, joystick_vals);
+		gamepad_read(&buttons, joystick_vals);
 		printf("buttons = %d\t joystick_vals = (", buttons);
 		for (int j = 0; j < 4; j++) {
 			printf("%f, ", joystick_vals[j]);


### PR DESCRIPTION
1) Added `STUDENTAPI` as a possible process
2) Cleaned up semaphore logic in both wrapper significantly (considering putting the `my_sem_*` functions in `runtime_util` actually, but for now they can stay in the wrappers)
3) Removed `process` argument from `gamepad_read` and `gamepad_write` functions