### PR TITLE
[SHM][NET_HANDLER] Added subscription requests to net_handler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,24 @@ install: skip
 # DOCKER_USERNAME is defined as a repository secret environment variable on travis-ci.org
 before_script:
   - docker pull ${DOCKER_USERNAME}/c-runtime:arm32
+  # - DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from avsurfer123/c-runtime:arm32 -t avsurfer123/c-runtime:arm32 -f docker/Dockerfile .
   - docker run -d ${DOCKER_USERNAME}/c-runtime:arm32 sleep 5m  # Runs the docker container as detached
 
-# -p 8101:8101/tcp -p 9000:9000/udp 
 script:
   - docker cp . $(docker ps -q):/root/runtime/ # Copy the newest code into the image
-  - docker exec -d $(docker ps -q) bash -c "./build.sh && ./run.sh" # Build and run with latest code
-  - sleep 30 # Wait for Runtime to build and run boot up, not best method
-  - docker exec -t $(docker ps -q) bash -c "cd net_handler && ./tcp_client 1 && ./udp_client"  # Run both test clients
+  - docker exec -t $(docker ps -q) bash -c "./build.sh" # Build the latest code
+  - docker exec -d $(docker ps -q) bash -c "./run.sh"   # Run the Runtime processes
+  - docker exec -t $(docker ps -q) bash -c "sleep 5 && cd net_handler && ./tcp_client 1 && ./udp_client"  # Run both test clients
   - docker stop -t 1 $(docker ps -q) # Stop the container when tests finish
+
+
+# Trying Docker automatic build instead
+# before_deploy:
+#   - docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+
+# deploy:
+#   - provider: script
+#     script: docker push ${DOCKER_USERNAME}/c-runtime:arm32
+#     on:
+#       branch: master
+#       condition: type = push

--- a/docker/README.md
+++ b/docker/README.md
@@ -23,7 +23,9 @@ To get the image to emulate a Raspberry Pi, do `docker pull avsurfer123/c-runtim
 
 ## Building
 
-To build your own image instead of using the one on Docker Hub, do `docker build -t avsurfer123/c-runtime:test -f docker/Dockerfile .`.
+To build your own image instead of using the one on Docker Hub, do 
+    
+    DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from avsurfer123/c-runtime:arm32 -t avsurfer123/c-runtime:arm32 -f docker/Dockerfile .
 
 ## Pushing
 

--- a/net_handler/Makefile
+++ b/net_handler/Makefile
@@ -13,7 +13,7 @@ ifeq ($(UNAME), Darwin)
 LIBS=-Wall
 endif
 
-all: gen_proto net_handler udp_client tcp_client proto_tests
+all: gen_proto net_handler udp_client tcp_client
 
 gen_proto: $(wildcard protos/*.proto)
 	cd protos && protoc-c --c_out ../$(GEN_FOLDER) *.proto

--- a/net_handler/net_handler.c
+++ b/net_handler/net_handler.c
@@ -19,7 +19,6 @@ int listening_socket_setup (int *sockfd)
 	if ((*sockfd = socket(AF_INET, SOCK_STREAM, 0)) == -1) {
 		perror("socket");
 		log_printf(ERROR, "failed to create listening socket");
-		logger_stop(NET_HANDLER);
 		return 1;
 	} else {
 		log_printf(DEBUG, "socket: successfully created listening socket");
@@ -41,7 +40,6 @@ int listening_socket_setup (int *sockfd)
 	if ((bind(*sockfd, (struct sockaddr *)&serv_addr, sizeof(struct sockaddr_in))) != 0) {
 		perror("bind");
 		log_printf(ERROR, "failed to bind listening socket to raspi port");
-		logger_stop(NET_HANDLER);
 		close(*sockfd);
 		return 1;
 	} else {
@@ -52,7 +50,6 @@ int listening_socket_setup (int *sockfd)
 	if ((listen(*sockfd, 2)) != 0) {
 		perror("listen");
 		log_printf(ERROR, "failed to set listening socket to listen mode");
-		logger_stop(NET_HANDLER);
 		close(*sockfd);
 		return 1;
 	} else {
@@ -94,7 +91,6 @@ int main ()
 	logger_init(NET_HANDLER);
 	signal(SIGINT, sigint_handler);
 	if (listening_socket_setup(&sockfd) != 0) {
-		logger_stop(NET_HANDLER);
 		if (sockfd != -1) {
 			close(sockfd);
 		}

--- a/net_handler/pbc_gen/device.pb-c.c
+++ b/net_handler/pbc_gen/device.pb-c.c
@@ -249,7 +249,7 @@ static const ProtobufCFieldDescriptor device__field_descriptors[4] =
     "type",
     3,
     PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_INT32,
+    PROTOBUF_C_TYPE_UINT32,
     0,   /* quantifier_offset */
     offsetof(Device, type),
     NULL,

--- a/net_handler/pbc_gen/device.pb-c.h
+++ b/net_handler/pbc_gen/device.pb-c.h
@@ -60,7 +60,7 @@ struct  _Device
   ProtobufCMessage base;
   char *name;
   uint64_t uid;
-  int32_t type;
+  uint32_t type;
   /*
    *each device has some number of params
    */

--- a/net_handler/protos/device.proto
+++ b/net_handler/protos/device.proto
@@ -20,7 +20,7 @@ message Param {
 message Device {
 	string name = 1;
 	uint64 uid = 2;
-	int32 type = 3;
+	uint32 type = 3;
 	repeated Param params = 4; //each device has some number of params
 }
 

--- a/net_handler/tcp_conn.c
+++ b/net_handler/tcp_conn.c
@@ -254,7 +254,25 @@ static int recv_new_msg (int conn_fd, int challenge_fd)
 			log_printf(ERROR, "Cannot unpack dev_data msg");
 			return -2;
 		}
-		log_printf(WARN, "Received device data msg which has no implementation");
+		for (int i = 0; i < dev_data_msg->n_devices; i++) {
+			Device* req_device = dev_data_msg->devices[i];
+			device_t* act_device = get_device(req_device->type);
+			if (act_device == NULL) {
+				log_printf(ERROR, "Invalid device subscription: device type %d is invalid", req_device->type);
+				continue;
+			}
+			uint32_t requests = 0;
+			for (int j = 0; j < req_device->n_params; j++) {
+				if (req_device->params[i]->val_case == PARAM__VAL_IVAL) {
+					// log_printf(DEBUG, "Received device subscription for %s param %s", act_device->name, act_device->params[j].name);
+					requests |= (req_device->params[j]->ival << j);
+				}
+			}
+			int err = place_sub_request(req_device->uid, NET_HANDLER, requests);
+			if (err == -1) {
+				log_printf(ERROR, "Invalid device subscription: device uid %llu is invalid", req_device->uid);
+			}
+		}
 		//TODO: tell UDP suite to only send parts of data, not implemented by Dawn yet
 		
 		dev_data__free_unpacked(dev_data_msg, NULL);

--- a/net_handler/tcp_conn.c
+++ b/net_handler/tcp_conn.c
@@ -1,4 +1,5 @@
 #include "tcp_conn.h"
+#include "pbc_gen/device.pb-c.h"
 
 //used for creating and cleaning up TCP connection
 typedef struct {
@@ -263,9 +264,9 @@ static int recv_new_msg (int conn_fd, int challenge_fd)
 			}
 			uint32_t requests = 0;
 			for (int j = 0; j < req_device->n_params; j++) {
-				if (req_device->params[i]->val_case == PARAM__VAL_IVAL) {
+				if (req_device->params[i]->val_case == PARAM__VAL_BVAL) {
 					// log_printf(DEBUG, "Received device subscription for %s param %s", act_device->name, act_device->params[j].name);
-					requests |= (req_device->params[j]->ival << j);
+					requests |= (req_device->params[j]->bval << j);
 				}
 			}
 			int err = place_sub_request(req_device->uid, NET_HANDLER, requests);

--- a/net_handler/test/tcp_client.c
+++ b/net_handler/test/tcp_client.c
@@ -148,7 +148,7 @@ int main (int argc, char* argv[])
 			else if (strcmp(mode_str, "idle\n") == 0) {
 				mode.mode = MODE__IDLE;
 			}
-			else if (strcmp(mode_str, "sub\n") == 0) {
+			else if (strcmp(mode_str, "off\n") == 0) {
 				// Send DEVICE DATA subscription
 				DevData dev_data = DEV_DATA__INIT;
 				dev_data.n_devices = 1;
@@ -175,7 +175,7 @@ int main (int argc, char* argv[])
 				free(send_buf);
 				continue;
 			}
-			else if (strcmp(mode_str, "all\n") == 0) {
+			else if (strcmp(mode_str, "on\n") == 0) {
 				DevData dev_data = DEV_DATA__INIT;
 				dev_data.n_devices = 1;
 				dev_data.devices = malloc(sizeof(Device*) * dev_data.n_devices);
@@ -190,8 +190,8 @@ int main (int argc, char* argv[])
 				for (int i = 0; i < device->n_params; i++) {
 					device->params[i] = malloc(sizeof(Param));
 					param__init(device->params[i]);
-					device->params[i]->ival = 1;
-					device->params[i]->val_case = PARAM__VAL_IVAL;
+					device->params[i]->bval = 1;
+					device->params[i]->val_case = PARAM__VAL_BVAL;
 				}
 				printf("Turning Polarbear on\n");
 				len_pb = dev_data__get_packed_size(&dev_data);

--- a/net_handler/test/tcp_client.c
+++ b/net_handler/test/tcp_client.c
@@ -167,7 +167,33 @@ int main (int argc, char* argv[])
 					device->params[i]->ival = 0;
 					device->params[i]->val_case = PARAM__VAL_IVAL;
 				}
-				printf("Made the dev_data msg\n");
+				printf("Turning Polarbear off\n");
+				len_pb = dev_data__get_packed_size(&dev_data);
+				send_buf = make_buf(DEVICE_DATA_MSG, len_pb);
+				dev_data__pack(&dev_data, send_buf + 3);
+				writen(sockfd, send_buf, len_pb + 3);
+				free(send_buf);
+				continue;
+			}
+			else if (strcmp(mode_str, "all\n") == 0) {
+				DevData dev_data = DEV_DATA__INIT;
+				dev_data.n_devices = 1;
+				dev_data.devices = malloc(sizeof(Device*) * dev_data.n_devices);
+				dev_data.devices[0] = malloc(sizeof(Device));
+				Device* device = dev_data.devices[0];
+				device__init(device);
+				device_t* polarbear = get_device(12);
+				device->n_params = polarbear->num_params;
+				device->type = 12;
+				device->uid = 2604648;
+				device->params = malloc(sizeof(Param*) * device->n_params);
+				for (int i = 0; i < device->n_params; i++) {
+					device->params[i] = malloc(sizeof(Param));
+					param__init(device->params[i]);
+					device->params[i]->ival = 1;
+					device->params[i]->val_case = PARAM__VAL_IVAL;
+				}
+				printf("Turning Polarbear on\n");
 				len_pb = dev_data__get_packed_size(&dev_data);
 				send_buf = make_buf(DEVICE_DATA_MSG, len_pb);
 				dev_data__pack(&dev_data, send_buf + 3);

--- a/net_handler/test/tcp_client.c
+++ b/net_handler/test/tcp_client.c
@@ -1,5 +1,4 @@
 #include "../net_util.h"
-#include "../../runtime_util/runtime_util.h"
 
 int sockfd = -1;
 
@@ -70,7 +69,7 @@ int main (int argc, char* argv[])
 	run_mode__pack(&run_mode, send_buf + 3);
 	writen(sockfd, send_buf, len_pb + 3); //write the message to the raspi
 	free(send_buf); // Free the allocated serialized buffer
-	
+
 	sleep(3);
 	Text inputs = TEXT__INIT;
 	inputs.n_payload = NUM_CHALLENGES;
@@ -147,7 +146,34 @@ int main (int argc, char* argv[])
 				mode.mode = MODE__TELEOP;
 			}
 			else if (strcmp(mode_str, "idle\n") == 0) {
-				// mode.mode = MODE__IDLE;
+				mode.mode = MODE__IDLE;
+			}
+			else if (strcmp(mode_str, "sub\n") == 0) {
+				// Send DEVICE DATA subscription
+				DevData dev_data = DEV_DATA__INIT;
+				dev_data.n_devices = 1;
+				dev_data.devices = malloc(sizeof(Device*) * dev_data.n_devices);
+				dev_data.devices[0] = malloc(sizeof(Device));
+				Device* device = dev_data.devices[0];
+				device__init(device);
+				device_t* polarbear = get_device(12);
+				device->n_params = polarbear->num_params;
+				device->type = 12;
+				device->uid = 2604648;
+				device->params = malloc(sizeof(Param*) * device->n_params);
+				for (int i = 0; i < device->n_params; i++) {
+					device->params[i] = malloc(sizeof(Param));
+					param__init(device->params[i]);
+					device->params[i]->ival = 0;
+					device->params[i]->val_case = PARAM__VAL_IVAL;
+				}
+				printf("Made the dev_data msg\n");
+				len_pb = dev_data__get_packed_size(&dev_data);
+				send_buf = make_buf(DEVICE_DATA_MSG, len_pb);
+				dev_data__pack(&dev_data, send_buf + 3);
+				writen(sockfd, send_buf, len_pb + 3);
+				free(send_buf);
+				continue;
 			}
 			else {
 				continue;

--- a/net_handler/test/udp_client.c
+++ b/net_handler/test/udp_client.c
@@ -1,11 +1,4 @@
-#include <stdio.h>       //for i/o
-#include <stdlib.h>      //for exit
-#include <string.h>      //for memset
-#include <arpa/inet.h>   //for inet_addr, bind, listen, accept, socket types
-#include <unistd.h>      //for read, write, close
-
 #include "../net_util.h"
-#include "../../runtime_util/runtime_util.h"
 
 float data[4] = {.012, 13.1, -.13, .30};
 

--- a/shm_wrapper/print_shm.c
+++ b/shm_wrapper/print_shm.c
@@ -18,7 +18,7 @@ int main (int argc, char *argv[])
 	
 	print_params(devices);
 	print_cmd_map();
-	print_sub_map();
+	print_sub_map(EXECUTOR);
 	print_robot_desc();
 	print_gamepad_state();
 	

--- a/shm_wrapper/shm.c
+++ b/shm_wrapper/shm.c
@@ -191,8 +191,8 @@ int main ()
 	dev_shm_ptr->catalog = 0;
 	for (int i = 0; i < MAX_DEVICES + 1; i++) {
 		dev_shm_ptr->cmd_map[i] = 0;
-		dev_shm_ptr->net_sub_map[i] = 0;
-		dev_shm_ptr->exec_sub_map[i] = 0;
+		dev_shm_ptr->net_sub_map[i] = -1;
+		dev_shm_ptr->exec_sub_map[i] = -1;
 	}
 	gp_shm_ptr->buttons = 0;
 	for (int i = 0; i < 4; i++) {

--- a/shm_wrapper/shm.c
+++ b/shm_wrapper/shm.c
@@ -192,7 +192,7 @@ int main ()
 	for (int i = 0; i < MAX_DEVICES + 1; i++) {
 		dev_shm_ptr->cmd_map[i] = 0;
 		dev_shm_ptr->net_sub_map[i] = -1;
-		dev_shm_ptr->exec_sub_map[i] = -1;
+		dev_shm_ptr->exec_sub_map[i] = 0;
 	}
 	gp_shm_ptr->buttons = 0;
 	for (int i = 0; i < 4; i++) {

--- a/shm_wrapper/shm_wrapper.c
+++ b/shm_wrapper/shm_wrapper.c
@@ -536,13 +536,15 @@ void device_disconnect (int dev_ix)
 	//update the catalog
 	dev_shm_ptr->catalog &= (~(1 << dev_ix));
 
-	//reset bitmap values to 0
+	//reset cmd bitmap values to 0
 	dev_shm_ptr->cmd_map[0] &= (~(1 << dev_ix));   //reset the changed bit flag in cmd_map[0]
 	dev_shm_ptr->cmd_map[dev_ix + 1] = 0;          //turn off all changed bits for the device
 
-	dev_shm_ptr->exec_sub_map[0] |= 1 << dev_ix;
-	dev_shm_ptr->exec_sub_map[dev_ix + 1] = -1;
+	// reset executor subscriptions to off
+	dev_shm_ptr->exec_sub_map[0] |= ~(1 << dev_ix);
+	dev_shm_ptr->exec_sub_map[dev_ix + 1] = 0;
 
+	// reset net_handler subscriptions to on
 	dev_shm_ptr->net_sub_map[0] |= 1 << dev_ix;
 	dev_shm_ptr->net_sub_map[dev_ix + 1] = -1;
 

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -190,9 +190,11 @@ int place_sub_request (uint64_t dev_uid, process_t process, uint32_t params_to_s
  *    - uint32_t sub_map[MAX_DEVICES + 1]: bitwise OR of the executor and net_handler sub_maps that will be put into this provided buffer
  *        (expects an array of 33 elements, where the 0th index is a bitmap indicating which devices require a new sub request to be sent,
  *        and the remaining 32 elements indicate what the subscription request to each device should be if there are changes)
+ *    - process_t process: If EXECUTOR, fills with executor subscriptions. If NET_HANDLER, fills with net_handler subscriptions. 
+ *                         If DEV_HANDLER, fills with subscriptions of both and also manages the bitmap. Else, fills with subscriptions of both.
  * No return value.
  */
-void get_sub_requests (uint32_t sub_map[MAX_DEVICES + 1]);
+void get_sub_requests (uint32_t sub_map[MAX_DEVICES + 1], process_t process);
 
 /*
  * Should be called from all processes that want to know current state of the command map (i.e. device handler)

--- a/shm_wrapper/shm_wrapper_test1.c
+++ b/shm_wrapper/shm_wrapper_test1.c
@@ -462,7 +462,7 @@ void subscription_test ()
 	
 	for (int i = 0; i < 6; i++) {
 		printf("Processing case %d from test2\n", i - 1);
-		get_sub_requests(sub_map);
+		get_sub_requests(sub_map, DEV_HANDLER);
 		if (sub_map[0] == 0) {
 			printf("No changed subscriptions\n");
 		} else {


### PR DESCRIPTION
Closes #40 
- Changed get_sub_requests to be different depending on the calling process
- Made net_handler subscriptions be default on, so that student can at first see all devices
- Added DevData processing code to tcp_conn which places sub requests
- Added check for the current sub requests when sending data in udp_conn
- Added test code in tcp_client to turn polarbear data off and on