### PR TITLE
Adds a Robot.log function to log arbitrary data, not just device params

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -e  # Makes any errors exit the script
 
 pushd executor && make && popd
 pushd net_handler && make && popd

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #/usr/bin/env bash
 
+set -e
+
 pushd executor && make && popd
 pushd net_handler && make && popd
 pushd shm_wrapper && make && popd

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,16 +27,30 @@ To build your own image instead of using the one on Docker Hub, so that it uses 
     
     DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1 -t avsurfer123/c-runtime:latest -f docker/Dockerfile .
 
+### Base Image
+
+We use a base image to make sure that the building of the actual image is fast. If for some reason the base image needs to be updated and pushed, do
+
+    DOCKER_BUILDKIT=1 cd docker/base && docker build --build-arg BUILDKIT_INLINE_CACHE=1 --cache-from avsurfer123/c-runtime:base -t avsurfer123/c-runtime:base .
+
+If you haven't run this already on your machine and so don't have local caches, it might take up to an hour.
+
 ## Running
 
 To run the latest Runtime inside a Docker container, do `docker run -it --rm avsurfer123/c-runtime:latest`. Then you can test by in another terminal doing `docker exec -it $(docker ps -q) bash` and running whatever you want inside the container. The `c-runtime` repo will be located at `/root/runtime`.
 
+### Devices
+
 If you want to have the container access any Arduino devices, add the flag `--device /dev/ttyACM0` or what ever devices you want to `docker run`.
+
+### SystemD
+
+If you want to run the Docker container with SystemD enabled as PID 1, do `docker run -it --rm --privileged avsurfer123/c-runtime:latest /lib/systemd/systemd` in one terminal. Then in another terminal, you can test with `docker exec -it $(docker ps -q) bash`. Then you can run Runtime from its SystemD service in `systemd/`. 
 
 ## Stopping
 
-To stop the container, either exit from the `docker run` shell with Ctrl+C or do `docker kill -s INT $(docker ps -q)`.
+To stop the container, either exit from the `./run.sh` shell with Ctrl+C or do `docker stop -t 5 $(docker ps -q)`.
 
 ## Pushing
 
-To push a built image to Docker Hub (only if you have push access), do `docker push avsurfer123/c-runtime:{TAG}`. You can change the tag before pushing by `docker tag avsurfer123/c-runtime:{OLD_TAG} avsurfer123/c-runtime:{NEW_TAG}`.
+To push a built image to Docker Hub (only if you have push access, talk to the Runtime PMs), do `docker push avsurfer123/c-runtime:{TAG}`. You can change the tag before pushing by `docker tag avsurfer123/c-runtime:{OLD_TAG} avsurfer123/c-runtime:{NEW_TAG}`.

--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -38,6 +38,10 @@ RUN wget https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_ARMv7
     rm -r ${arduino_folder} && \
     arduino-cli core update-index
 
+# Install SystemD
+RUN apt-get -y install systemd
+STOPSIGNAL SIGRTMIN+3
+
 # Install debug packages
 RUN apt-get -y install procps htop tmux nano
 

--- a/executor/executor.c
+++ b/executor/executor.c
@@ -388,7 +388,6 @@ void python_exit_handler(int signum) {
  *  Kills any running subprocess. Will make the robot go into IDLE mode.
  */
 void kill_subprocess() {
-    log_printf(DEBUG, "In KILL subprocess");
     if (kill(pid, SIGTERM) != 0) {
         log_printf(ERROR, "Kill signal not sent: %s", strerror(errno));
     } 

--- a/executor/runtime.pxd
+++ b/executor/runtime.pxd
@@ -12,7 +12,7 @@ cdef extern from "../runtime_util/runtime_util.h":
         uint8_t num_params
         param_desc_t* params
     ctypedef union param_val_t:
-        int p_i
+        int16_t p_i
         float p_f
         uint8_t p_b
     ctypedef enum param_type_t:

--- a/executor/runtime.pxd
+++ b/executor/runtime.pxd
@@ -12,7 +12,7 @@ cdef extern from "../runtime_util/runtime_util.h":
         uint8_t num_params
         param_desc_t* params
     ctypedef union param_val_t:
-        int16_t p_i
+        int32_t p_i
         float p_f
         uint8_t p_b
     ctypedef enum param_type_t:
@@ -51,5 +51,4 @@ cdef extern from "../shm_wrapper/shm_wrapper.h" nogil:
     int gamepad_read (uint32_t *pressed_buttons, float *joystick_vals)
     robot_desc_val_t robot_desc_read (robot_desc_field_t field)
     int place_sub_request (uint64_t dev_uid, process_t process, uint32_t params_to_sub)
-    int log_data_write(param_desc_t desc, param_val_t value)
-    int log_data_read(uint8_t* num_params, param_desc_t descs[], param_val_t values[])
+    int log_data_write(char* key, param_type_t type, param_val_t value)

--- a/executor/runtime.pxd
+++ b/executor/runtime.pxd
@@ -20,6 +20,8 @@ cdef extern from "../runtime_util/runtime_util.h":
     ctypedef struct param_desc_t:
         char* name
         param_type_t type
+        uint8_t read
+        uint8_t write
     ctypedef enum robot_desc_field_t:
         GAMEPAD, START_POS, RUN_MODE
     ctypedef enum robot_desc_val_t:
@@ -49,3 +51,5 @@ cdef extern from "../shm_wrapper/shm_wrapper.h" nogil:
     int gamepad_read (uint32_t *pressed_buttons, float *joystick_vals)
     robot_desc_val_t robot_desc_read (robot_desc_field_t field)
     int place_sub_request (uint64_t dev_uid, process_t process, uint32_t params_to_sub)
+    int log_data_write(param_desc_t desc, param_val_t value)
+    int log_data_read(uint8_t* num_params, param_desc_t descs[], param_val_t values[])

--- a/executor/studentapi.pyx
+++ b/executor/studentapi.pyx
@@ -164,6 +164,26 @@ cdef class Robot:
         return False
 
 
+    cpdef void log(self, str key, value) except *:
+        cdef param_val_t param
+        cdef param_desc_t desc
+        desc.name = key.encode('utf-8')
+        if type(value) == int:
+            param.p_i = value
+            desc.type = INT
+        elif type(value) == float:
+            param.p_f = value
+            desc.type = FLOAT
+        elif type(value) == bool:
+            param.p_b = int(value)
+            desc.type = BOOL
+        else:
+            _print(f"Cannot log parameter {key} with type {type(key).__name__} since it's not an int, float, or bool.", level=ERROR)
+            return
+        custom_write(param, desc)
+        
+
+
     cpdef get_value(self, str device_id, str param_name):
         """ 
         Get a device value. 

--- a/executor/studentapi.pyx
+++ b/executor/studentapi.pyx
@@ -166,24 +166,21 @@ cdef class Robot:
 
     cpdef void log(self, str key, value) except *:
         cdef param_val_t param
-        cdef param_desc_t desc
+        cdef param_type_t param_type
         cdef bytes key_bytes = key.encode('utf-8')
-        desc.name = key_bytes
         if type(value) == int:
             param.p_i = value
-            desc.type = INT
+            param_type = INT
         elif type(value) == float:
             param.p_f = value
-            desc.type = FLOAT
+            param_type = FLOAT
         elif type(value) == bool:
             param.p_b = int(value)
-            desc.type = BOOL
+            param_type = BOOL
         else:
-            raise ValueError(f"Cannot log parameter {key} with type {type(key).__name__} since it's not an int, float, or bool.")
+            raise ValueError(f"Cannot log parameter {key} with type {type(value).__name__} since it's not an int, float, or bool.")
 
-        desc.read = 1
-        desc.write = 1
-        cdef int err = log_data_write(desc, param)
+        cdef int err = log_data_write(key_bytes, param_type, param)
         if err == -1:
             raise IndexError(f"Maximum number of 255 log data keys reached. can't add key {key}")
         

--- a/executor/studentcode.py
+++ b/executor/studentcode.py
@@ -48,6 +48,7 @@ def autonomous_main():
     global i, start
     if i % 10000 == 0:
         print("Iteration:", i, time.time() - start)
+        Robot.log("iteration time", time.time() - start)
         start = time.time()
         # Robot.run(double, 5.0)
     i += 1

--- a/net_handler/tcp_conn.c
+++ b/net_handler/tcp_conn.c
@@ -1,5 +1,4 @@
 #include "tcp_conn.h"
-#include "pbc_gen/device.pb-c.h"
 
 //used for creating and cleaning up TCP connection
 typedef struct {

--- a/net_handler/udp_conn.c
+++ b/net_handler/udp_conn.c
@@ -1,5 +1,4 @@
 #include "udp_conn.h"
-#include "pbc_gen/device.pb-c.h"
 
 pthread_t gp_thread, device_thread;
 int socket_fd = -1;
@@ -21,9 +20,9 @@ void* send_device_data(void* args) {
 	int valid_dev_idxs[MAX_DEVICES];
 	uint32_t catalog;
 
-	param_val_t custom_params[MAX_PARAMS];
-	param_desc_t custom_desc[MAX_PARAMS];
-	int num_params;
+	param_val_t custom_params[UCHAR_MAX];
+	param_desc_t custom_desc[UCHAR_MAX];
+	uint8_t num_params;
 
 	while (1) {
 		DevData dev_data = DEV_DATA__INIT;
@@ -96,7 +95,8 @@ void* send_device_data(void* args) {
 		Device* custom = malloc(sizeof(Device));
 		device__init(custom);
 		dev_data.devices[dev_idx] = custom;
-		custom_read(&num_params, custom_params, custom_desc);
+		log_printf(DEBUG, "about to read from SHM");
+		log_data_read(&num_params, custom_desc, custom_params);
 		custom->n_params = num_params;
 		custom->name = "CustomData";
 		custom->type = MAX_DEVICES;

--- a/net_handler/udp_conn.c
+++ b/net_handler/udp_conn.c
@@ -1,11 +1,11 @@
 #include "udp_conn.h"
 
-pthread_t gp_thread, device_thread;
-int socket_fd = -1;
-struct sockaddr_in dawn_addr = {0};
-socklen_t addr_len = sizeof(struct sockaddr_in);
+pthread_t gp_thread, device_thread;					// thread IDs for receiving gamepad data and sending device data
+int socket_fd = -1;									// the UDP socket's file descriptor
+struct sockaddr_in dawn_addr = {0};					// the address of our client, which should be Dawn
+socklen_t addr_len = sizeof(struct sockaddr_in);	// length of the address
 
-uint64_t start_time;
+uint64_t start_time;	// the time that Runtime/net_handler was started, in milliseconds since the UNIX epoch
 
 
 void* send_device_data(void* args) {

--- a/net_handler/udp_conn.c
+++ b/net_handler/udp_conn.c
@@ -5,6 +5,8 @@ int socket_fd = -1;
 struct sockaddr_in dawn_addr = {0};
 socklen_t addr_len = sizeof(struct sockaddr_in);
 
+uint64_t start_time;
+
 
 void* send_device_data(void* args) {
 	int len;
@@ -21,7 +23,8 @@ void* send_device_data(void* args) {
 	uint32_t catalog;
 
 	param_val_t custom_params[UCHAR_MAX];
-	param_desc_t custom_desc[UCHAR_MAX];
+	param_type_t custom_types[UCHAR_MAX];
+	char custom_names[UCHAR_MAX][64];
 	uint8_t num_params;
 
 	while (1) {
@@ -40,7 +43,7 @@ void* send_device_data(void* args) {
 				num_devices++;
 			}
 		}
-		dev_data.devices = malloc((num_devices + 1) * sizeof(Device *));
+		dev_data.devices = malloc((num_devices + 1) * sizeof(Device *)); // + 1 is for custom data
 
 		//populate dev_data.device[i]
 		int dev_idx = 0;
@@ -90,22 +93,23 @@ void* send_device_data(void* args) {
 			}
 			dev_idx++;
 		}
-		dev_data.n_devices = dev_idx + 1;
 
+		// Add custom log data to protobuf
 		Device* custom = malloc(sizeof(Device));
 		device__init(custom);
 		dev_data.devices[dev_idx] = custom;
-		log_printf(DEBUG, "about to read from SHM");
-		log_data_read(&num_params, custom_desc, custom_params);
-		custom->n_params = num_params;
+		log_data_read(&num_params, custom_names, custom_types, custom_params);
+		custom->n_params = num_params + 1; // + 1 is for the current time
+		custom->params = malloc(sizeof(Param*) * custom->n_params);
 		custom->name = "CustomData";
 		custom->type = MAX_DEVICES;
 		custom->uid = 0;
 		for (int i = 0; i < custom->n_params; i++) {
 			Param* param = malloc(sizeof(Param));
 			param__init(param);
-			param->name = custom_desc[i].name;
-			switch (custom_desc[i].type) {
+			custom->params[i] = param;
+			param->name = custom_names[i];
+			switch (custom_types[i]) {
 				case INT:
 					param->val_case = PARAM__VAL_IVAL;
 					param->ival = custom_params[i].p_i;
@@ -119,9 +123,15 @@ void* send_device_data(void* args) {
 					param->bval = custom_params[i].p_b;
 					break;
 			}
-			custom->params[i] = param;
 		}
+		Param* time = malloc(sizeof(Param));
+		param__init(time);
+		custom->params[num_params] = time;
+		time->name = "time_ms";
+		time->val_case = PARAM__VAL_IVAL;
+		time->ival = millis() - start_time; // Can only give difference in millisecond since robot start since it is int32, not int64
 
+		dev_data.n_devices = dev_idx + 1; // + 1 is for custom data
 
 		len = dev_data__get_packed_size(&dev_data);
 		// log_printf(DEBUG, "Number of actual devices: %d, total size %d, DevData size %d", dev_idx, len, sizeof(DevData));
@@ -157,7 +167,7 @@ void* update_gamepad_state(void* args) {
 
 	while (1) {
 		recvlen = recvfrom(socket_fd, buffer, size, 0, (struct sockaddr*) &dawn_addr, &addr_len);
-		log_printf(DEBUG, "Dawn IP is %s:%d", inet_ntoa(dawn_addr.sin_addr), ntohs(dawn_addr.sin_port));
+		// log_printf(DEBUG, "Dawn IP is %s:%d", inet_ntoa(dawn_addr.sin_addr), ntohs(dawn_addr.sin_port));
 		if (recvlen == size) {
 			log_printf(WARN, "UDP: Read length matches read buffer size %d", recvlen);
 		}
@@ -175,11 +185,11 @@ void* update_gamepad_state(void* args) {
 		}
 		else {
 			// display the message's fields.
-			//log_printf(DEBUG, "Is gamepad connected: %d. Received: buttons = %d\n\taxes:", gp_state->connected, gp_state->buttons);
-			//for (int i = 0; i < gp_state->n_axes; i++) {
-			//	log_printf(PYTHON, "\t%f", gp_state->axes[i]);
-			//}
-			//log_printf(PYTHON, "\n");
+			// log_printf(DEBUG, "Is gamepad connected: %d. Received: buttons = %d\n\taxes:", gp_state->connected, gp_state->buttons);
+			// for (int i = 0; i < gp_state->n_axes; i++) {
+			// 	log_printf(PYTHON, "\t%f", gp_state->axes[i]);
+			// }
+			// log_printf(PYTHON, "\n");
 
 			robot_desc_write(GAMEPAD,  gp_state->connected ? CONNECTED : DISCONNECTED);
 			if (gp_state->connected) {
@@ -211,6 +221,8 @@ void start_udp_conn ()
 		log_printf(ERROR, "udp socket bind failed: %s", strerror(errno));
 		return;
 	}
+
+	start_time = millis();
 
 	//create threads
 	if (pthread_create(&gp_thread, NULL, update_gamepad_state, NULL) != 0) {

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 
 cd shm_wrapper && ./shm &
 sleep 0.5

--- a/runtime_util/runtime_util.c
+++ b/runtime_util/runtime_util.c
@@ -256,7 +256,7 @@ char** get_joystick_names() {
 
 /* Returns the number of milliseconds since the Unix Epoch */
 uint64_t millis() {
-	struct timeval time; // Holds the current time in seconds + microsecondsx
+	struct timeval time; // Holds the current time in seconds + microseconds
 	gettimeofday(&time, NULL);
 	uint64_t s1 = (uint64_t)(time.tv_sec) * 1000;  // Convert seconds to milliseconds
 	uint64_t s2 = (time.tv_usec / 1000);		   // Convert microseconds to milliseconds

--- a/runtime_util/runtime_util.h
+++ b/runtime_util/runtime_util.h
@@ -62,7 +62,7 @@ typedef enum param_type {
 
 //hold a single param value. One-to-one mapping to param_val_t enum
 typedef union {
-	int16_t p_i; //data if int
+	int32_t p_i; //data if int
 	float p_f;   //data if float
 	uint8_t p_b; //data if bool
 } param_val_t;

--- a/shm_wrapper/print_shm.c
+++ b/shm_wrapper/print_shm.c
@@ -17,6 +17,7 @@ int main (int argc, char *argv[])
 	shm_init();
 	
 	print_params(devices);
+	print_custom_data();
 	print_cmd_map();
 	print_sub_map(EXECUTOR);
 	print_robot_desc();

--- a/shm_wrapper/shm.c
+++ b/shm_wrapper/shm.c
@@ -231,7 +231,7 @@ int main ()
 	rd_shm_ptr->fields[GAMEPAD] = DISCONNECTED;
 	rd_shm_ptr->fields[START_POS] = LEFT;
 
-	log_data_shm_ptr->num_params = 0;
+	memset(log_data_shm_ptr, 0, sizeof(log_data_shm_t));
 	
 	//now we just stall and wait
 	while (1) {

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -66,7 +66,8 @@ typedef struct robot_desc_shm {
 typedef struct {
 	uint8_t num_params;
 	param_val_t params[UCHAR_MAX];
-	param_desc_t desc[UCHAR_MAX];
+	char names[UCHAR_MAX][64];
+	param_type_t types[UCHAR_MAX];
 } log_data_shm_t;
 
 // ******************************************* PRINTING UTILITIES ***************************************** //
@@ -105,6 +106,13 @@ void print_robot_desc ();
  * Prints the current state of the gamepad in a human-readable way
  */
 void print_gamepad_state ();
+
+
+/*
+ *	Prints the current custom logged data.
+ */
+void print_custom_data();
+
 
 // ******************************************* WRAPPER FUNCTIONS ****************************************** //
 
@@ -271,10 +279,26 @@ int gamepad_read (uint32_t *pressed_buttons, float joystick_vals[4]);
  */
 int gamepad_write (uint32_t pressed_buttons, float joystick_vals[4]);
 
+/**
+* 	Write the given custom parameter to shared memory. 
+*	Args:
+*		- key is name of the parameter
+*		- type is type of the parameter
+*		- value is the value of the parameter, with the corresponding type filled with data
+*	Returns:
+*		0 if successful
+*		-1 if the maximum number of custom parameters is reached so this parameter isn't written
+*/
+int log_data_write(char* key, param_type_t type, param_val_t value);
 
-int log_data_write(param_desc_t desc, param_val_t value);
-
-int log_data_read(uint8_t* num_params, param_desc_t descs[UCHAR_MAX], param_val_t values[UCHAR_MAX]);
-
+/**
+*	Reads the custom log data from shared memory.
+*	Args:
+*		- num_params is a pointer to an int that will get filled with the number of custom parameters
+*		- names is a 2D char array that will be filled with the parameter names, up to `num_params`. Assumes that every parameter name is less than 64 characters long
+*		- types is an array and will be filled with the parameter types, up to `num_params`
+*		- values is an array and will be filled with the parameter values, up to `num_params`
+*/
+void log_data_read(uint8_t* num_params, char names[UCHAR_MAX][64], param_type_t types[UCHAR_MAX], param_val_t values[UCHAR_MAX]);
 
 #endif

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -10,8 +10,10 @@
 #include <unistd.h>                        //for standard symbolic constants
 #include <semaphore.h>                     //for semaphores
 #include <sys/mman.h>                      //for posix shared memory
+#include <limits.h>						   //for UCHAR_MAX
 #include "../logger/logger.h"              //for logger
 #include "../runtime_util/runtime_util.h"  //for runtime constants
+
 
 //names of various objects used in shm_wrapper; should not be used outside of shm_wrapper and shm.c
 #define CATALOG_MUTEX_NAME "/ct-mutex"  //name of semaphore used as a mutex on the catalog
@@ -24,8 +26,8 @@
 #define GP_MUTEX_NAME "/gp-sem"         //name of semaphore used as mutex over gamepad shm
 #define RD_MUTEX_NAME "/rd-sem"         //name of semaphore used as mutex over robot description shm
 
-#define CUSTOM_SHM_NAME "/custom-shm"
-#define CUSTOM_SHM_MUTEX "/custom-sem"
+#define LOG_DATA_SHM "/log-data-shm"
+#define LOG_DATA_MUTEX "/log-data-sem"
 
 #define SNAME_SIZE 32 //size of buffers that hold semaphore names, in bytes
 
@@ -63,9 +65,9 @@ typedef struct robot_desc_shm {
 
 typedef struct {
 	uint8_t num_params;
-	param_val_t params[MAX_PARAMS];
-	param_desc_t desc[MAX_PARAMS];
-} custom_shm_t;
+	param_val_t params[UCHAR_MAX];
+	param_desc_t desc[UCHAR_MAX];
+} log_data_shm_t;
 
 // ******************************************* PRINTING UTILITIES ***************************************** //
 
@@ -268,5 +270,11 @@ int gamepad_read (uint32_t *pressed_buttons, float joystick_vals[4]);
  * Returns 0 on success, -1 on failure (if gamepad is not connected)
  */
 int gamepad_write (uint32_t pressed_buttons, float joystick_vals[4]);
+
+
+int log_data_write(param_desc_t desc, param_val_t value);
+
+int log_data_read(uint8_t* num_params, param_desc_t descs[UCHAR_MAX], param_val_t values[UCHAR_MAX]);
+
 
 #endif

--- a/shm_wrapper/shm_wrapper.h
+++ b/shm_wrapper/shm_wrapper.h
@@ -24,6 +24,9 @@
 #define GP_MUTEX_NAME "/gp-sem"         //name of semaphore used as mutex over gamepad shm
 #define RD_MUTEX_NAME "/rd-sem"         //name of semaphore used as mutex over robot description shm
 
+#define CUSTOM_SHM_NAME "/custom-shm"
+#define CUSTOM_SHM_MUTEX "/custom-sem"
+
 #define SNAME_SIZE 32 //size of buffers that hold semaphore names, in bytes
 
 // *********************************** SHM TYPEDEFS  ****************************************************** //
@@ -57,6 +60,12 @@ typedef struct gp_shm {
 typedef struct robot_desc_shm {
 	uint8_t fields[NUM_DESC_FIELDS];   //array to hold the robot state (each is a uint8_t)
 } robot_desc_shm_t;
+
+typedef struct {
+	uint8_t num_params;
+	param_val_t params[MAX_PARAMS];
+	param_desc_t desc[MAX_PARAMS];
+} custom_shm_t;
 
 // ******************************************* PRINTING UTILITIES ***************************************** //
 

--- a/test.sh
+++ b/test.sh
@@ -13,8 +13,8 @@ function sigint_handler {
         clean_up
 	fi
 	# if temp.txt exists, we Ctrl-C'ed in the middle of a running test and we need to remove it
-	if [[ -f temp.txt ]]; then
-		rm temp.txt
+	if [[ -f /tmp/temp_logs.txt ]]; then
+		rm /tmp/temp_logs.txt
 	fi
 	exit 1
 }

--- a/tests/client/net_handler_client.c
+++ b/tests/client/net_handler_client.c
@@ -78,16 +78,14 @@ static void recv_udp_data (int udp_fd)
 		fprintf(udp_output_fp, "recvfrom: %s\n", strerror(errno));
 	}
 	fprintf(udp_output_fp, "Raspi IP is %s:%d\n", inet_ntoa(recvaddr.sin_addr), ntohs(recvaddr.sin_port));
-	fprintf(udp_output_fp, "Received data size %d\n", recv_size);
 	DevData* dev_data = dev_data__unpack(NULL, recv_size, msg);
 	if (dev_data == NULL) {
 		printf("Error unpacking incoming message\n");
 	}
 	
 	// display the message's fields.
-	fprintf(udp_output_fp, "Received:\n");
 	for (int i = 0; i < dev_data->n_devices; i++) {
-		fprintf(udp_output_fp, "Device No. %d: ", i);
+		fprintf(udp_output_fp, "Device No. %d:", i);
 		fprintf(udp_output_fp, "\ttype = %s, uid = %llu, itype = %d\n", dev_data->devices[i]->name, dev_data->devices[i]->uid, dev_data->devices[i]->type);
 		fprintf(udp_output_fp, "\tParams:\n");
 		for (int j = 0; j < dev_data->devices[i]->n_params; j++) {

--- a/tests/integration/tc_68_4.c
+++ b/tests/integration/tc_68_4.c
@@ -20,8 +20,7 @@ char check_output_1[] =
 
 char check_output_2[] =
 	"Raspi IP is 127.0.0.1:9000\n"
-	"Received data size 0\n"
-	"Received:\n";
+	"Device No. 0:\ttype = CustomData, uid = 0, itype = 32\n";
 
 int main ()
 {

--- a/tests/test.c
+++ b/tests/test.c
@@ -1,6 +1,6 @@
 #include "test.h"
 
-#define TEMP_FILE "temp.txt"
+#define TEMP_FILE "/tmp/temp_logs.txt"
 
 pid_t output_redirect;          //holds process ID of output redirection process
 FILE *temp_fp;                  //file pointer of open temp file


### PR DESCRIPTION
Closes #64 
In order to do this:
- a new SHM block was added called `log_data` and has a corresponding semaphore
- new SHM functions were added that can read, write, and print this data
- new API function Robot.log was added that calls `log_data_write`
- udp_conn's send_device_data was modified to add on a CustomData device with these logged parameters
- as a bonus, the CustomData will always include the number of milliseconds since the Robot started so making graphs is easier for Dawn